### PR TITLE
feat: add response types

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -43,3 +43,14 @@ export interface SendEmailRequest {
   /** Attachments */
   attachments?: any[];
 }
+
+interface EmailResponse extends Pick<SendEmailRequest, 'to' | 'from'> {
+  id: string;
+  created_at: string;
+}
+
+interface ErrorResponse {
+  error: { message: string; status: number; type: string };
+}
+
+export type SendEmailResponse = EmailResponse | ErrorResponse;

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import { render } from '@react-email/render';
-import { SendEmailData, SendEmailRequest } from './interfaces';
+import { SendEmailData, SendEmailRequest, SendEmailResponse } from './interfaces';
 import { version } from '../package.json';
 
 export class Resend {
@@ -34,7 +34,7 @@ export class Resend {
     });
   }
 
-  async sendEmail(data: SendEmailData): Promise<object> {
+  async sendEmail(data: SendEmailData): Promise<SendEmailResponse> {
     try {
       const path = `${this.baseUrl}/email`;
 


### PR DESCRIPTION
## Context 

Add response types for `sendEmail()` covered the success and error scenarios 