### PR TITLE
feat: Map error response type

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -54,7 +54,7 @@ export interface SendEmailRequest {
 }
 
 export const RESEND_ERROR_CODES_BY_KEY = {
-  missing_required_fields: 400,
+  missing_required_fields: 422,
   missing_api_key: 401,
   invalid_api_Key: 403,
   invalid_from_address: 403,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -53,13 +53,28 @@ export interface SendEmailRequest {
   tags?: Tag[];
 }
 
+export const RESEND_ERROR_CODES_BY_KEY = {
+  missing_required_fields: 400,
+  missing_api_key: 401,
+  invalid_api_Key: 403,
+  invalid_from_address: 403,
+  not_found: 404,
+  method_not_allowed: 405,
+  internal_server_error: 500
+} as const;
+
+type ValueOf<TObj> = TObj[keyof TObj];
+
+export type RESEND_ERROR_CODE_NUMBER = ValueOf<typeof RESEND_ERROR_CODES_BY_KEY>;
+export type RESEND_ERROR_CODE_KEY = keyof typeof RESEND_ERROR_CODES;
+
 interface EmailResponse extends Pick<SendEmailRequest, 'to' | 'from'> {
   id: string;
   created_at: string;
 }
 
 interface ErrorResponse {
-  error: { message: string; status: number; type: string };
+  error: { message: string; status: RESEND_ERROR_CODE_NUMBER; type: RESEND_ERROR_CODE_KEY };
 }
 
 export type SendEmailResponse = EmailResponse | ErrorResponse;


### PR DESCRIPTION
Rather than just returning string/number these new types give developers a better idea of what errors the might receive. 

This setup was inspired by how TRPC types it's codes: https://github.com/trpc/trpc/blob/main/packages/server/src/rpc/codes.ts

I think it would be great and take this one step further by unifying the return types. There's no reason type, status, and message couldn't exist on the returned success value too.