### PR TITLE
fix: Allow null in the type definition for CreateEmailOptions.react

### DIFF
--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -7,7 +7,7 @@ export interface CreateEmailOptions {
   cc?: string | string[];
   from: string;
   html?: string;
-  react?: ReactElement;
+  react?: ReactElement | null;
   reply_to?: string | string[];
   subject: string;
   tags?: Tag[];


### PR DESCRIPTION
This PR fixed #104 .