### PR TITLE
fix: Ensure either `text` or `html` is a required field

### DIFF
--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -14,16 +14,18 @@ interface CreateEmailBaseOptions {
 }
 
 interface CreateEmailWithHtmlOptions extends CreateEmailBaseOptions {
-  html: string
-  text?: string
+  html: string;
+  text?: string;
 }
 
 interface CreateEmailWithTextOptions extends CreateEmailBaseOptions {
-  html?: string
-  text: string
+  html?: string;
+  text: string;
 }
 
-export type CreateEmailOptions = CreateEmailWithHtmlOptions | CreateEmailWithTextOptions
+export type CreateEmailOptions =
+  | CreateEmailWithHtmlOptions
+  | CreateEmailWithTextOptions;
 
 export interface CreateEmailRequestOptions extends PostOptions {}
 

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -1,19 +1,29 @@
 import { ReactElement } from 'react';
 import { PostOptions } from '../../common/interfaces';
 
-export interface CreateEmailOptions {
+interface CreateEmailBaseOptions {
   attachments?: Attachment[];
   bcc?: string | string[];
   cc?: string | string[];
   from: string;
-  html?: string;
   react?: ReactElement | null;
   reply_to?: string | string[];
   subject: string;
   tags?: Tag[];
-  text?: string;
   to: string | string[];
 }
+
+interface CreateEmailWithHtmlOptions extends CreateEmailBaseOptions {
+  html: string
+  text?: string
+}
+
+interface CreateEmailWithTextOptions extends CreateEmailBaseOptions {
+  html?: string
+  text: string
+}
+
+export type CreateEmailOptions = CreateEmailWithHtmlOptions | CreateEmailWithTextOptions
 
 export interface CreateEmailRequestOptions extends PostOptions {}
 

--- a/src/resend.spec.ts
+++ b/src/resend.spec.ts
@@ -1,6 +1,7 @@
 import { Resend } from './resend';
 import MockAdapater from 'axios-mock-adapter';
 import axios from 'axios';
+import { CreateEmailOptions } from './emails/interfaces';
 
 const mock = new MockAdapater(axios);
 const resend = new Resend('re_924b3rjh2387fbewf823');
@@ -13,10 +14,11 @@ describe('Resend', () => {
   });
 
   it('sends email', async () => {
-    const payload = {
+    const payload: CreateEmailOptions = {
       from: 'bu@resend.com',
       to: 'zeno@resend.com',
       subject: 'Hello World',
+      html: '<h1>Hello world</h1>',
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -37,10 +39,11 @@ describe('Resend', () => {
   });
 
   it('sends email with multiple recipients', async () => {
-    const payload = {
+    const payload: CreateEmailOptions = {
       from: 'admin@resend.com',
       to: ['bu@resend.com', 'zeno@resend.com'],
       subject: 'Hello World',
+      text: 'Hello world'
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -64,11 +67,12 @@ describe('Resend', () => {
   });
 
   it('sends email with multiple bcc recipients', async () => {
-    const payload = {
+    const payload: CreateEmailOptions = {
       from: 'admin@resend.com',
       to: 'bu@resend.com',
       bcc: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
+      text: 'Hello world'
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -94,11 +98,12 @@ describe('Resend', () => {
   });
 
   it('sends email with multiple cc recipients', async () => {
-    const payload = {
+    const payload: CreateEmailOptions = {
       from: 'admin@resend.com',
       to: 'bu@resend.com',
       cc: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
+      text: 'Hello world'
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -124,11 +129,12 @@ describe('Resend', () => {
   });
 
   it('sends email with multiple replyTo emails', async () => {
-    const apiPayload = {
+    const apiPayload: CreateEmailOptions = {
       from: 'admin@resend.com',
       to: 'bu@resend.com',
       reply_to: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
+      text: 'Hello world'
     };
 
     mock.onPost('/emails', apiPayload).replyOnce(200, {
@@ -139,11 +145,12 @@ describe('Resend', () => {
       created_at: '123',
     });
 
-    const payload = {
+    const payload: CreateEmailOptions = {
       from: 'admin@resend.com',
       to: 'bu@resend.com',
       reply_to: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
+      text: 'Hello world'
     };
 
     const data = await resend.emails.send(payload);

--- a/src/resend.spec.ts
+++ b/src/resend.spec.ts
@@ -43,7 +43,7 @@ describe('Resend', () => {
       from: 'admin@resend.com',
       to: ['bu@resend.com', 'zeno@resend.com'],
       subject: 'Hello World',
-      text: 'Hello world'
+      text: 'Hello world',
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -72,7 +72,7 @@ describe('Resend', () => {
       to: 'bu@resend.com',
       bcc: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
-      text: 'Hello world'
+      text: 'Hello world',
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -103,7 +103,7 @@ describe('Resend', () => {
       to: 'bu@resend.com',
       cc: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
-      text: 'Hello world'
+      text: 'Hello world',
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -134,7 +134,7 @@ describe('Resend', () => {
       to: 'bu@resend.com',
       reply_to: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
-      text: 'Hello world'
+      text: 'Hello world',
     };
 
     mock.onPost('/emails', apiPayload).replyOnce(200, {
@@ -150,7 +150,7 @@ describe('Resend', () => {
       to: 'bu@resend.com',
       reply_to: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
-      text: 'Hello world'
+      text: 'Hello world',
     };
 
     const data = await resend.emails.send(payload);


### PR DESCRIPTION
This PR updates the `CreateEmailOptions` type to ensure either `text` or `html` is set for the email payload to be valid.

This will ensure that either `CreateEmailWithHtmlOptions` or `CreateEmailWithTextOptions` is required. This change also allows both `html` & `text` to be used at the same time.

This PR also updates the tests to ensure that any mock tests without `html` or `text` contain either on of the fields.