### PR TITLE
feat: Add JSdoc for create email types

### DIFF
--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -6,6 +6,7 @@ interface CreateEmailBaseOptions {
   bcc?: string | string[];
   cc?: string | string[];
   from: string;
+  headers?: Record<string, string>
   react?: ReactElement | null;
   reply_to?: string | string[];
   subject: string;

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -40,13 +40,23 @@ interface CreateEmailBaseOptions {
    */
   react?: React.ReactElement | React.ReactNode | null;
   /**
+   * The HTML version of the message.
+   * 
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
+  html?: string;
+  /**
+   * The plain text version of the message.
+   * 
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
+  text?: string;
+  /**
    * Reply-to email address. For multiple addresses, send as an array of strings.
    *
    * @link https://resend.com/api-reference/emails/send-email#body-parameters
    */
   reply_to?: string | string[];
-  html?: string;
-  text?: string;
   /**
    * Email subject.
    *

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -69,6 +69,11 @@ interface CreateEmailBaseOptions {
    * @link https://resend.com/api-reference/emails/send-email#body-parameters
    */
   tags?: Tag[];
+  /**
+   * Recipient email address. For multiple addresses, send as an array of strings. Max 50.
+   * 
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
   to: string | string[];
 }
 

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -2,40 +2,109 @@ import { ReactElement } from 'react';
 import { PostOptions } from '../../common/interfaces';
 
 interface CreateEmailBaseOptions {
+  /**
+   * Filename and content of attachments (max 40mb per email)
+   *
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
   attachments?: Attachment[];
+  /**
+   * Blind carbon copy recipient email address. For multiple addresses, send as an array of strings.
+   *
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
   bcc?: string | string[];
+  /**
+   * Carbon copy recipient email address. For multiple addresses, send as an array of strings.
+   *
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
   cc?: string | string[];
+  /**
+   * Sender email address. To include a friendly name, use the format `"Your Name <sender@domain.com>"`
+   *
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
   from: string;
-  headers?: Record<string, string>
+  /**
+   * Custom headers to add to the email.
+   *
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
+  headers?: Record<string, string>;
+  /**
+   * The React component used to write the message.
+   *
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
   react?: ReactElement | null;
+  /**
+   * Reply-to email address. For multiple addresses, send as an array of strings.
+   *
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
   reply_to?: string | string[];
+  /**
+   * Email subject.
+   *
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
   subject: string;
+  /**
+   * Email tags
+   *
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
   tags?: Tag[];
+  /**
+   * Recipient email address. For multiple addresses, send as an array of strings. Max 50.
+   *
+   * @link https://resend.com/api-reference/emails/send-email#body-parameters
+   */
   to: string | string[];
 }
 
 interface CreateEmailWithHtmlOptions extends CreateEmailBaseOptions {
-  html: string
-  text?: string
+  /** The HTML version of the message. */
+  html: string;
+  /** The plain text version of the message. */
+  text?: string;
 }
 
 interface CreateEmailWithTextOptions extends CreateEmailBaseOptions {
-  html?: string
-  text: string
+  /** The HTML version of the message. */
+  html?: string;
+  /** The plain text version of the message. */
+  text: string;
 }
 
-export type CreateEmailOptions = CreateEmailWithHtmlOptions | CreateEmailWithTextOptions
+export type CreateEmailOptions =
+  | CreateEmailWithHtmlOptions
+  | CreateEmailWithTextOptions;
 
 export interface CreateEmailRequestOptions extends PostOptions {}
 
 export interface CreateEmailResponse {
+  /** The ID of the newly created email. */
   id: string;
 }
 
 interface Attachment {
+  /** Content of an attached file. */
   content?: string | Buffer;
+  /** Name of attached file. */
   filename?: string | false | undefined;
+  /** Path where the attachment file is hosted */
   path?: string;
 }
 
-export type Tag = { name: string; value: string };
+export type Tag = {
+  /**
+   * The name of the email tag. It can only contain ASCII letters (a–z, A–Z), numbers (0–9), underscores (_), or dashes (-). It can contain no more than 256 characters.
+   */
+  name: string;
+  /**
+   * The value of the email tag. It can only contain ASCII letters (a–z, A–Z), numbers (0–9), underscores (_), or dashes (-). It can contain no more than 256 characters.
+   */
+  value: string;
+};

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -1,19 +1,29 @@
 import { ReactElement } from 'react';
 import { PostOptions } from '../../common/interfaces';
 
-export interface CreateEmailOptions {
+interface CreateEmailBaseOptions {
   attachments?: Attachment[];
   bcc?: string | string[];
   cc?: string | string[];
   from: string;
-  html?: string;
   react?: ReactElement | null;
   reply_to?: string | string[];
   subject: string;
   tags?: Tag[];
-  text?: string;
   to: string | string[];
 }
+
+interface CreateEmailWithHtmlOptions extends CreateEmailBaseOptions {
+  html: string
+  text?: string
+}
+
+interface CreateEmailWithTextOptions extends CreateEmailBaseOptions {
+  html?: string
+  text: string
+}
+
+export type CreateEmailOptions = CreateEmailWithHtmlOptions | CreateEmailWithTextOptions
 
 export interface CreateEmailRequestOptions extends PostOptions {}
 

--- a/src/resend.spec.ts
+++ b/src/resend.spec.ts
@@ -1,6 +1,7 @@
 import { Resend } from './resend';
 import MockAdapater from 'axios-mock-adapter';
 import axios from 'axios';
+import { CreateEmailOptions } from './emails/interfaces';
 
 const mock = new MockAdapater(axios);
 const resend = new Resend('re_924b3rjh2387fbewf823');
@@ -13,10 +14,11 @@ describe('Resend', () => {
   });
 
   it('sends email', async () => {
-    const payload = {
+    const payload: CreateEmailOptions = {
       from: 'bu@resend.com',
       to: 'zeno@resend.com',
       subject: 'Hello World',
+      html: '<h1>Hello world</h1>',
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -37,10 +39,11 @@ describe('Resend', () => {
   });
 
   it('sends email with multiple recipients', async () => {
-    const payload = {
+    const payload: CreateEmailOptions = {
       from: 'admin@resend.com',
       to: ['bu@resend.com', 'zeno@resend.com'],
       subject: 'Hello World',
+      text: 'Hello world'
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -64,11 +67,12 @@ describe('Resend', () => {
   });
 
   it('sends email with multiple bcc recipients', async () => {
-    const payload = {
+    const payload: CreateEmailOptions = {
       from: 'admin@resend.com',
       to: 'bu@resend.com',
       bcc: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
+      text: 'Hello world'
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -94,11 +98,12 @@ describe('Resend', () => {
   });
 
   it('sends email with multiple cc recipients', async () => {
-    const payload = {
+    const payload: CreateEmailOptions = {
       from: 'admin@resend.com',
       to: 'bu@resend.com',
       cc: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
+      text: 'Hello world'
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -124,11 +129,12 @@ describe('Resend', () => {
   });
 
   it('sends email with multiple replyTo emails', async () => {
-    const apiPayload = {
+    const apiPayload: CreateEmailOptions = {
       from: 'admin@resend.com',
       to: 'bu@resend.com',
       reply_to: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
+      text: 'Hello world'
     };
 
     mock.onPost('/emails', apiPayload).replyOnce(200, {
@@ -139,11 +145,12 @@ describe('Resend', () => {
       created_at: '123',
     });
 
-    const payload = {
+    const payload: CreateEmailOptions = {
       from: 'admin@resend.com',
       to: 'bu@resend.com',
       reply_to: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
+      text: 'Hello world'
     };
 
     const data = await resend.emails.send(payload);

--- a/src/resend.spec.ts
+++ b/src/resend.spec.ts
@@ -43,7 +43,7 @@ describe('Resend', () => {
       from: 'admin@resend.com',
       to: ['bu@resend.com', 'zeno@resend.com'],
       subject: 'Hello World',
-      text: 'Hello world'
+      text: 'Hello world',
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -72,7 +72,7 @@ describe('Resend', () => {
       to: 'bu@resend.com',
       bcc: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
-      text: 'Hello world'
+      text: 'Hello world',
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -103,7 +103,7 @@ describe('Resend', () => {
       to: 'bu@resend.com',
       cc: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
-      text: 'Hello world'
+      text: 'Hello world',
     };
     mock.onPost('/emails', payload).replyOnce(200, {
       id: '1234',
@@ -134,7 +134,7 @@ describe('Resend', () => {
       to: 'bu@resend.com',
       reply_to: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
-      text: 'Hello world'
+      text: 'Hello world',
     };
 
     mock.onPost('/emails', apiPayload).replyOnce(200, {
@@ -150,7 +150,7 @@ describe('Resend', () => {
       to: 'bu@resend.com',
       reply_to: ['foo@resend.com', 'bar@resend.com'],
       subject: 'Hello World',
-      text: 'Hello world'
+      text: 'Hello world',
     };
 
     const data = await resend.emails.send(payload);
@@ -163,6 +163,40 @@ describe('Resend', () => {
           "foo@resend.com",
           "bar@resend.com",
         ],
+        "to": "bu@resend.com",
+      }
+    `);
+  });
+
+  it('can send an email with headers', async () => {
+    const payload: CreateEmailOptions = {
+      from: 'admin@resend.com',
+      headers: {
+        'X-Entity-Ref-ID': '123',
+      },
+      subject: 'Hello World',
+      text: 'Hello world',
+      to: 'bu@resend.com',
+    };
+    mock.onPost('/emails', payload).replyOnce(200, {
+      id: '1234',
+      from: 'admin@resend.com',
+      to: 'bu@resend.com',
+      headers: {
+        'X-Entity-Ref-ID': '123',
+      },
+      created_at: '123',
+    });
+
+    const data = await resend.emails.send(payload);
+    expect(data).toMatchInlineSnapshot(`
+      {
+        "created_at": "123",
+        "from": "admin@resend.com",
+        "headers": {
+          "X-Entity-Ref-ID": "123",
+        },
+        "id": "1234",
         "to": "bu@resend.com",
       }
     `);


### PR DESCRIPTION
This PR adds JSDoc's for all types in the SDK. This allows the developer to quickly view information about a particular property without having to visit the documentation.