### PR TITLE
feat: add topic_id to email and broadcast endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "4.7.0-preview-topics.1",
+  "version": "4.7.0-preview-topics.2",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -368,6 +368,7 @@ describe('Broadcasts', () => {
         created_at: '2024-12-01T19:32:22.980Z',
         scheduled_at: null,
         sent_at: null,
+        topic_id: '9f31e56e-3083-46cf-8e96-c6995e0e576a',
       };
 
       fetchMock.mockOnce(JSON.stringify(response), {
@@ -397,6 +398,7 @@ describe('Broadcasts', () => {
     "sent_at": null,
     "status": "draft",
     "subject": "hello world",
+    "topic_id": "9f31e56e-3083-46cf-8e96-c6995e0e576a",
   },
   "error": null,
 }

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -63,6 +63,7 @@ export class Broadcasts {
         reply_to: payload.replyTo,
         subject: payload.subject,
         text: payload.text,
+        topic_id: payload.topicId,
       },
       options,
     );
@@ -117,6 +118,7 @@ export class Broadcasts {
         subject: payload.subject,
         reply_to: payload.replyTo,
         preview_text: payload.previewText,
+        topic_id: payload.topicId,
       },
     );
     return data;

--- a/src/broadcasts/interfaces/broadcast.ts
+++ b/src/broadcasts/interfaces/broadcast.ts
@@ -10,4 +10,5 @@ export interface Broadcast {
   created_at: string;
   scheduled_at: string | null;
   sent_at: string | null;
+  topic_id?: string | null;
 }

--- a/src/broadcasts/interfaces/create-broadcast-options.interface.ts
+++ b/src/broadcasts/interfaces/create-broadcast-options.interface.ts
@@ -61,6 +61,12 @@ interface CreateBroadcastBaseOptions {
    * @link https://resend.com/docs/api-reference/broadcasts/create#body-parameters
    */
   subject: string;
+  /**
+   * The id of the topic you want to send to
+   *
+   * @link https://resend.com/docs/api-reference/broadcasts/create#body-parameters
+   */
+  topicId?: string | null;
 }
 
 export type CreateBroadcastOptions = RequireAtLeastOne<EmailRenderOptions> &

--- a/src/broadcasts/interfaces/update-broadcast.interface.ts
+++ b/src/broadcasts/interfaces/update-broadcast.interface.ts
@@ -13,6 +13,7 @@ export interface UpdateBroadcastOptions {
   subject?: string;
   replyTo?: string[];
   previewText?: string;
+  topicId?: string | null;
 }
 
 export interface UpdateBroadcastResponse {

--- a/src/common/interfaces/email-api-options.interface.ts
+++ b/src/common/interfaces/email-api-options.interface.ts
@@ -12,6 +12,7 @@ export interface EmailApiOptions {
   bcc?: string | string[];
   cc?: string | string[];
   reply_to?: string | string[];
+  topic_id?: string | null;
   scheduled_at?: string;
   tags?: Tag[];
   attachments?: Attachment[];

--- a/src/common/utils/parse-email-to-api-options.ts
+++ b/src/common/utils/parse-email-to-api-options.ts
@@ -17,5 +17,6 @@ export function parseEmailToApiOptions(
     tags: email.tags,
     text: email.text,
     to: email.to,
+    topic_id: email.topicId,
   };
 }

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -60,6 +60,7 @@ describe('Emails', () => {
         to: 'user@resend.com',
         subject: 'Not Idempotent Test',
         html: '<h1>Test</h1>',
+        topicId: '9f31e56e-3083-46cf-8e96-c6995e0e576a',
       };
 
       await resend.emails.create(payload);
@@ -68,7 +69,11 @@ describe('Emails', () => {
       const lastCall = fetchMock.mock.calls[0];
       expect(lastCall).toBeDefined();
 
-      console.log('debug:', lastCall[1]?.headers);
+      // Make sure the topic_id is included in the body
+      expect(lastCall[1]?.body).toEqual(
+        '{"from":"admin@resend.com","html":"<h1>Test</h1>","subject":"Not Idempotent Test","to":"user@resend.com","topic_id":"9f31e56e-3083-46cf-8e96-c6995e0e576a"}',
+      );
+
       //@ts-ignore
       const hasIdempotencyKey = lastCall[1]?.headers.has('Idempotency-Key');
       expect(hasIdempotencyKey).toBeFalsy();

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -81,6 +81,12 @@ interface CreateEmailBaseOptions {
    */
   to: string | string[];
   /**
+   * The id of the topic you want to send to
+   *
+   * @link https://resend.com/docs/api-reference/emails/send-email#body-parameters
+   */
+  topicId?: string | null;
+  /**
    * Schedule email to be sent later.
    * The date should be in ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z).
    *

--- a/src/emails/interfaces/get-email-options.interface.ts
+++ b/src/emails/interfaces/get-email-options.interface.ts
@@ -23,6 +23,7 @@ export interface GetEmailResponseSuccess {
   subject: string;
   text: string | null;
   to: string[];
+  topic_id?: string | null;
   scheduled_at: string | null;
   object: 'email';
 }


### PR DESCRIPTION
This PR updates the relevant Email and Broadcast endpoints to include the `topic_id` field.