### PR TITLE
feat: add verify webhooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "url": "https://github.com/resend/resend-node/issues"
   },
   "homepage": "https://github.com/resend/resend-node#readme",
+  "dependencies": {
+    "svix": "1.76.1"
+  },
   "peerDependencies": {
     "@react-email/render": "*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@react-email/render':
         specifier: '*'
         version: 1.2.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      svix:
+        specifier: 1.76.1
+        version: 1.76.1
     devDependencies:
       '@biomejs/biome':
         specifier: 2.2.5
@@ -773,6 +776,9 @@ packages:
     resolution: {integrity: sha512-suq9tRQ6bkpMukTG5K5z0sPWB7t0zExMzZCdmYm6xTSSIm/yCKNm7VCL36wVeyTsFr597/UhU1OAYdHGMDiHrw==}
     engines: {node: '>=10'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -1073,6 +1079,9 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+
   esbuild@0.25.8:
     resolution: {integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==}
     engines: {node: '>=18'}
@@ -1106,6 +1115,9 @@ packages:
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1655,6 +1667,9 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  svix@1.76.1:
+    resolution: {integrity: sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -1775,6 +1790,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -2463,6 +2482,8 @@ snapshots:
 
   '@sindresorhus/fnv1a@2.0.1': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2730,6 +2751,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  es6-promise@4.2.8: {}
+
   esbuild@0.25.8:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.8
@@ -2837,6 +2860,8 @@ snapshots:
   fast-deep-equal@2.0.1: {}
 
   fast-json-stable-stringify@2.1.0: {}
+
+  fast-sha256@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -3427,6 +3452,15 @@ snapshots:
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
 
+  svix@1.76.1:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      '@types/node': 22.18.9
+      es6-promise: 4.2.8
+      fast-sha256: 1.3.0
+      url-parse: 1.5.10
+      uuid: 10.0.0
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -3527,6 +3561,8 @@ snapshots:
   utf8-byte-length@1.0.5: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@10.0.0: {}
 
   validate-npm-package-name@5.0.1: {}
 

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -13,6 +13,7 @@ import { Emails } from './emails/emails';
 import type { ErrorResponse } from './interfaces';
 import { Templates } from './templates/templates';
 import { Topics } from './topics/topics';
+import { Webhooks } from './webhooks/webhooks';
 
 const defaultBaseUrl = 'https://api.resend.com';
 const defaultUserAgent = `resend-node:${version}`;
@@ -38,6 +39,7 @@ export class Resend {
   readonly emails = new Emails(this);
   readonly templates = new Templates(this);
   readonly topics = new Topics(this);
+  readonly webhooks = new Webhooks();
 
   constructor(readonly key?: string) {
     if (!key) {

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -1,0 +1,51 @@
+import { Webhook } from 'svix';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Webhooks } from './webhooks';
+
+const mocks = vi.hoisted(() => {
+  const verify = vi.fn();
+  const webhookConstructor = vi.fn(() => ({
+    verify,
+  }));
+
+  return {
+    verify,
+    webhookConstructor,
+  };
+});
+
+vi.mock('svix', () => ({
+  Webhook: mocks.webhookConstructor,
+}));
+
+describe('Webhooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.verify.mockReset();
+  });
+
+  it('verifies payload using svix headers', () => {
+    const options = {
+      payload: '{"type":"email.sent"}',
+      headers: {
+        id: 'msg_123',
+        timestamp: '1713984875',
+        signature: 'v1,some-signature',
+      },
+      webhookSecret: 'whsec_123',
+    };
+
+    const expectedResult = { id: 'msg_123', status: 'verified' };
+    mocks.verify.mockReturnValue(expectedResult);
+
+    const result = new Webhooks().verify(options);
+
+    expect(Webhook).toHaveBeenCalledWith(options.webhookSecret);
+    expect(mocks.verify).toHaveBeenCalledWith(options.payload, {
+      'svix-id': options.headers.id,
+      'svix-timestamp': options.headers.timestamp,
+      'svix-signature': options.headers.signature,
+    });
+    expect(result).toBe(expectedResult);
+  });
+});

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -1,0 +1,24 @@
+import { Webhook } from 'svix';
+
+interface Headers {
+  id: string;
+  timestamp: string;
+  signature: string;
+}
+
+interface VerifyWebhookOptions {
+  payload: string;
+  headers: Headers;
+  webhookSecret: string;
+}
+
+export class Webhooks {
+  verify(payload: VerifyWebhookOptions) {
+    const webhook = new Webhook(payload.webhookSecret);
+    return webhook.verify(payload.payload, {
+      'svix-id': payload.headers.id,
+      'svix-timestamp': payload.headers.timestamp,
+      'svix-signature': payload.headers.signature,
+    });
+  }
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add webhook verification to the SDK using Svix so apps can validate incoming Resend webhooks. Introduces a simple Webhooks.verify helper and exposes it via Resend.webhooks.

- **New Features**
  - Webhooks.verify(payload, { id, timestamp, signature }, webhookSecret) maps to svix headers and returns the verification result.
  - Exposes Resend.webhooks for easy access.

- **Dependencies**
  - Added svix@1.76.1.

<!-- End of auto-generated description by cubic. -->

