### PR TITLE
feat: add GET for inbound emails v0

### DIFF
--- a/src/inbound/inbound.spec.ts
+++ b/src/inbound/inbound.spec.ts
@@ -1,0 +1,258 @@
+import type { ErrorResponse } from '../interfaces';
+import { Resend } from '../resend';
+import type { GetInboundEmailResponseSuccess } from './interfaces/get-inbound-email.interface';
+
+const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+describe('Inbound', () => {
+  afterEach(() => fetchMock.resetMocks());
+
+  describe('get', () => {
+    describe('when inbound email not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          message: 'Inbound email not found',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          },
+        });
+
+        const result = resend.inbound.get(
+          '987770eb-185c-4059-ab73-f0faad7c05d3',
+        );
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Inbound email not found",
+    "name": "not_found",
+  },
+}
+`);
+      });
+    });
+
+    it('gets inbound email', async () => {
+      const response: GetInboundEmailResponseSuccess = {
+        object: 'inbound_email',
+        id: '987770eb-185c-4059-ab73-f0faad7c05d3',
+        to: ['delivered@resend.dev'],
+        from: 'sender@example.com',
+        subject: 'Test Email',
+        html: '<p>Hello World</p>',
+        text: 'Hello World',
+        reply_to: null,
+        cc: [],
+        bcc: [],
+        created_at: '2024-09-29T12:00:00.000Z',
+        attachments: null,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      await expect(
+        resend.inbound.get('987770eb-185c-4059-ab73-f0faad7c05d3'),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "attachments": null,
+    "bcc": [],
+    "cc": [],
+    "created_at": "2024-09-29T12:00:00.000Z",
+    "from": "sender@example.com",
+    "html": "<p>Hello World</p>",
+    "id": "987770eb-185c-4059-ab73-f0faad7c05d3",
+    "object": "inbound_email",
+    "reply_to": null,
+    "subject": "Test Email",
+    "text": "Hello World",
+    "to": [
+      "delivered@resend.dev",
+    ],
+  },
+  "error": null,
+}
+`);
+    });
+
+    it('gets inbound email with attachments and converts to Buffer', async () => {
+      // Simulating how attachment content comes from the API (as serialized buffer data)
+      const mockBufferData = [72, 101, 108, 108, 111]; // "Hello" in ASCII
+
+      const response = {
+        object: 'inbound_email',
+        id: '987770eb-185c-4059-ab73-f0faad7c05d3',
+        to: ['delivered@resend.dev'],
+        from: 'sender@example.com',
+        subject: 'Test Email with Attachment',
+        html: '<p>Email with attachment</p>',
+        text: 'Email with attachment',
+        reply_to: null,
+        cc: [],
+        bcc: [],
+        created_at: '2024-09-29T12:00:00.000Z',
+        attachments: [
+          {
+            filename: 'test.txt',
+            contentType: 'text/plain',
+            size: 5,
+            contentDisposition: 'attachment',
+            content: { data: mockBufferData }, // Simulating Buffer serialization
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const result = await resend.inbound.get(
+        '987770eb-185c-4059-ab73-f0faad7c05d3',
+      );
+
+      expect(result.data).not.toBeNull();
+      expect(result.error).toBeNull();
+
+      if (result.data) {
+        expect(result.data.attachments).toBeDefined();
+        expect(result.data.attachments).toHaveLength(1);
+
+        const attachment = result.data.attachments?.[0];
+        expect(attachment?.filename).toBe('test.txt');
+        expect(attachment?.contentType).toBe('text/plain');
+        expect(attachment?.size).toBe(5);
+
+        // Verify that content was converted to Buffer
+        expect(Buffer.isBuffer(attachment?.content)).toBe(true);
+        expect((attachment?.content as Buffer).toString()).toBe('Hello');
+      }
+    });
+
+    it('gets inbound email with base64 attachment and converts to Buffer', async () => {
+      const base64Content = Buffer.from('Hello World').toString('base64');
+
+      const response = {
+        object: 'inbound_email',
+        id: '987770eb-185c-4059-ab73-f0faad7c05d3',
+        to: ['delivered@resend.dev'],
+        from: 'sender@example.com',
+        subject: 'Test Email with Base64 Attachment',
+        html: '<p>Email with base64 attachment</p>',
+        text: 'Email with base64 attachment',
+        reply_to: null,
+        cc: [],
+        bcc: [],
+        created_at: '2024-09-29T12:00:00.000Z',
+        attachments: [
+          {
+            filename: 'document.pdf',
+            contentType: 'application/pdf',
+            size: 11,
+            content: base64Content,
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const result = await resend.inbound.get(
+        '987770eb-185c-4059-ab73-f0faad7c05d3',
+      );
+
+      expect(result.data).not.toBeNull();
+      expect(result.error).toBeNull();
+
+      if (result.data) {
+        expect(result.data.attachments).toBeDefined();
+        expect(result.data.attachments).toHaveLength(1);
+
+        const attachment = result.data.attachments?.[0];
+        expect(attachment?.filename).toBe('document.pdf');
+        expect(attachment?.contentType).toBe('application/pdf');
+
+        // Verify that base64 content was converted to Buffer
+        expect(Buffer.isBuffer(attachment?.content)).toBe(true);
+        expect((attachment?.content as Buffer).toString()).toBe('Hello World');
+      }
+    });
+
+    it('gets inbound email with multiple recipients', async () => {
+      const response: GetInboundEmailResponseSuccess = {
+        object: 'inbound_email',
+        id: '987770eb-185c-4059-ab73-f0faad7c05d3',
+        to: ['user1@resend.dev', 'user2@resend.dev'],
+        from: 'sender@example.com',
+        subject: 'Multiple Recipients',
+        html: '<p>Hello Multiple Recipients</p>',
+        text: 'Hello Multiple Recipients',
+        reply_to: ['reply@example.com'],
+        cc: ['cc@example.com'],
+        bcc: ['bcc@example.com'],
+        created_at: '2024-09-29T12:00:00.000Z',
+        attachments: null,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      await expect(
+        resend.inbound.get('987770eb-185c-4059-ab73-f0faad7c05d3'),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "attachments": null,
+    "bcc": [
+      "bcc@example.com",
+    ],
+    "cc": [
+      "cc@example.com",
+    ],
+    "created_at": "2024-09-29T12:00:00.000Z",
+    "from": "sender@example.com",
+    "html": "<p>Hello Multiple Recipients</p>",
+    "id": "987770eb-185c-4059-ab73-f0faad7c05d3",
+    "object": "inbound_email",
+    "reply_to": [
+      "reply@example.com",
+    ],
+    "subject": "Multiple Recipients",
+    "text": "Hello Multiple Recipients",
+    "to": [
+      "user1@resend.dev",
+      "user2@resend.dev",
+    ],
+  },
+  "error": null,
+}
+`);
+    });
+  });
+});

--- a/src/inbound/inbound.ts
+++ b/src/inbound/inbound.ts
@@ -1,0 +1,62 @@
+import type { Resend } from '../resend';
+import type {
+  GetInboundEmailResponse,
+  GetInboundEmailResponseSuccess,
+} from './interfaces/get-inbound-email.interface';
+import type { InboundEmailAttachment } from './interfaces/inbound-email';
+
+export class Inbound {
+  constructor(private readonly resend: Resend) {}
+
+  private processAttachments(
+    attachments: InboundEmailAttachment[] | null,
+  ): InboundEmailAttachment[] | null {
+    if (!attachments) return null;
+
+    return attachments.map((attachment) => {
+      if (attachment.content) {
+        // Handle content that comes from JSON serialization with a data property
+        if (
+          typeof attachment.content === 'object' &&
+          'data' in attachment.content &&
+          Array.isArray((attachment.content as { data: number[] }).data)
+        ) {
+          return {
+            ...attachment,
+            content: Buffer.from(
+              (attachment.content as { data: number[] }).data,
+            ),
+          };
+        }
+
+        // If content is a string (base64), convert to Buffer
+        if (typeof attachment.content === 'string') {
+          return {
+            ...attachment,
+            content: Buffer.from(attachment.content, 'base64'),
+          };
+        }
+      }
+      return attachment;
+    });
+  }
+
+  async get(id: string): Promise<GetInboundEmailResponse> {
+    const result = await this.resend.get<GetInboundEmailResponseSuccess>(
+      `/emails/inbound/${id}`,
+    );
+
+    // Process attachments to convert content to Buffers
+    if (result.data?.attachments) {
+      return {
+        ...result,
+        data: {
+          ...result.data,
+          attachments: this.processAttachments(result.data.attachments),
+        },
+      };
+    }
+
+    return result;
+  }
+}

--- a/src/inbound/interfaces/get-inbound-email.interface.ts
+++ b/src/inbound/interfaces/get-inbound-email.interface.ts
@@ -1,0 +1,16 @@
+import type { ErrorResponse } from '../../interfaces';
+import type { InboundEmail } from './inbound-email';
+
+export interface GetInboundEmailResponseSuccess extends InboundEmail {
+  object: 'inbound_email';
+}
+
+export type GetInboundEmailResponse =
+  | {
+      data: GetInboundEmailResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/inbound/interfaces/inbound-email.ts
+++ b/src/inbound/interfaces/inbound-email.ts
@@ -1,0 +1,23 @@
+export interface InboundEmailAttachment {
+  filename?: string;
+  contentType?: string;
+  size?: number;
+  contentDisposition?: string;
+  contentId?: string;
+  content?: Buffer | string;
+  path?: string;
+}
+
+export interface InboundEmail {
+  id: string;
+  to: string[];
+  from: string;
+  created_at: string;
+  subject: string;
+  bcc: string[];
+  cc: string[];
+  reply_to: string | string[] | null;
+  html: string;
+  text: string;
+  attachments: InboundEmailAttachment[] | null;
+}

--- a/src/inbound/interfaces/index.ts
+++ b/src/inbound/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './get-inbound-email.interface';
+export * from './inbound-email';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export * from './common/interfaces';
 export * from './contacts/interfaces';
 export * from './domains/interfaces';
 export * from './emails/interfaces';
+export * from './inbound/interfaces';
 export { ErrorResponse } from './interfaces';
 export { Resend } from './resend';

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -9,6 +9,7 @@ import type { PatchOptions } from './common/interfaces/patch-option.interface';
 import { Contacts } from './contacts/contacts';
 import { Domains } from './domains/domains';
 import { Emails } from './emails/emails';
+import { Inbound } from './inbound/inbound';
 import type { ErrorResponse } from './interfaces';
 
 const defaultBaseUrl = 'https://api.resend.com';
@@ -32,6 +33,7 @@ export class Resend {
   readonly contacts = new Contacts(this);
   readonly domains = new Domains(this);
   readonly emails = new Emails(this);
+  readonly inbound = new Inbound(this);
 
   constructor(readonly key?: string) {
     if (!key) {


### PR DESCRIPTION
This PR adds a `resend.inbound.get` function to get inbound emails with their bodies and attachments. It also turns the serialized buffers into proper buffers for users to do whatever they want with them.

## Example usage

```js
const resend = new Resend(process.env.RESEND_API_KEY);

async function testInboundGet() {
  console.log('Fetching inbound email: 987770eb-185c-4059-ab73-f0faad7c05d3\n');

  const result = await resend.inbound.get('987770eb-185c-4059-ab73-f0faad7c05d3');

  if (result.error) {
    console.error('Error:', result.error);
    return;
  }

  const email = result.data;

  console.log(email)
}
```

The code above yields, for example:

```js
{
  object: 'inbound-email',
  id: '987770eb-185c-4059-ab73-f0faad7c05d3',
  to: [ 'inbox@inbound.resend.app' ],
  from: 'felipe@resend.com',
  created_at: '2025-09-29 21:20:13.778196+00',
  subject: 'testing with attachments',
  bcc: [],
  cc: [],
  reply_to: [],
  html: '<div dir="ltr">123 </div>\n',
  text: '123\n',
  attachments: [
    {
      content: <Buffer 25 50 44 46 2d 31 2e 37 0a 0a 31 20 30 20 6f 62 6a 0a 20 20 3c 3c 20 2f 4c 65 6e 67 74 68 20 32 20 30 20 52 20 3e 3e 0a 73 74 72 65 61 6d 0a 30 2e 35 ... 80843 more bytes>,
      filename: 'invoice.pdf'
    },
    {
      content: <Buffer 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52 00 00 02 c1 00 00 02 d0 08 06 00 00 00 71 3b ad 4a 00 00 80 00 49 44 41 54 78 da 94 fd e9 93 24 49 92 ... 607509 more bytes>,
      filename: 'image_720.png'
    }
  ]
}
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds resend.inbound.get to retrieve inbound emails with body and attachments. Converts attachment content to Buffers so you can read and process files easily.

- **New Features**
  - New Inbound client with get(id) calling /emails/inbound/:id.
  - Normalizes attachment content to Buffer (handles serialized data and base64).
  - Exports inbound email interfaces and wires inbound into the Resend client.

<!-- End of auto-generated description by cubic. -->

