### PR TITLE
chore: bump to 6.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Have to do this directly to main because there is already an active release on canary. After this, we'll have to rebase canary onto main.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bump version from 6.1.1 to 6.1.2 to publish a patch release. Merging directly to main due to an active canary release; rebase canary onto main after merge.

<!-- End of auto-generated description by cubic. -->

