### PR TITLE
chore: bump to 6.2.0-canary.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.2.0-canary.0",
+  "version": "6.2.0-canary.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
This is so that the peer dependencies fix goes into canary as well

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped package version to 6.2.0-canary.1 to include the peer dependencies fix in the canary release.

<!-- End of auto-generated description by cubic. -->

