### PR TITLE
feat: show headers in response

### DIFF
--- a/src/inbound/inbound.spec.ts
+++ b/src/inbound/inbound.spec.ts
@@ -52,6 +52,9 @@ describe('Inbound', () => {
           bcc: null,
           cc: ['cc@example.com'],
           reply_to: ['reply@example.com'],
+          headers: {
+            example: 'value',
+          },
           attachments: [
             {
               id: 'att_123',
@@ -93,6 +96,9 @@ describe('Inbound', () => {
     ],
     "createdAt": "2023-04-07T23:13:52.669661+00:00",
     "from": "sender@example.com",
+    "headers": {
+      "example": "value",
+    },
     "html": "<p>hello world</p>",
     "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
     "object": "inbound",
@@ -123,6 +129,7 @@ describe('Inbound', () => {
           bcc: null,
           cc: null,
           reply_to: null,
+          headers: {},
           attachments: [],
         };
 
@@ -146,6 +153,7 @@ describe('Inbound', () => {
     "cc": null,
     "createdAt": "2023-04-07T23:13:52.669661+00:00",
     "from": "sender@example.com",
+    "headers": {},
     "html": null,
     "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
     "object": "inbound",

--- a/src/inbound/inbound.ts
+++ b/src/inbound/inbound.ts
@@ -35,6 +35,7 @@ export class Inbound {
       replyTo: apiResponse.reply_to,
       html: apiResponse.html,
       text: apiResponse.text,
+      headers: apiResponse.headers,
       attachments: apiResponse.attachments.map((attachment) => ({
         id: attachment.id,
         filename: attachment.filename,

--- a/src/inbound/interfaces/get-inbound-email.interface.ts
+++ b/src/inbound/interfaces/get-inbound-email.interface.ts
@@ -14,6 +14,7 @@ export interface GetInboundEmailApiResponse {
   reply_to: string[] | null;
   html: string | null;
   text: string | null;
+  headers: Record<string, string>;
   attachments: Array<{
     id: string;
     filename: string;

--- a/src/inbound/interfaces/inbound-email.ts
+++ b/src/inbound/interfaces/inbound-email.ts
@@ -9,6 +9,7 @@ export interface InboundEmail {
   replyTo: string[] | null;
   html: string | null;
   text: string | null;
+  headers: Record<string, string>;
   attachments: InboundEmailAttachment[];
 }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Expose email headers in inbound email responses so apps can use them for routing, filtering, and debugging. Adds a headers field to the API and SDK response.

- **New Features**
  - Added headers: Record<string, string> to GetInboundEmailApiResponse and InboundEmail.
  - Mapped apiResponse.headers to InboundEmail.headers.

<!-- End of auto-generated description by cubic. -->

