### PR TITLE
feat: add inbound listing method

### DIFF
--- a/src/emails/receiving/interfaces/index.ts
+++ b/src/emails/receiving/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './get-inbound-email.interface';
+export * from './list-inbound-emails.interface';

--- a/src/emails/receiving/interfaces/list-inbound-emails.interface.ts
+++ b/src/emails/receiving/interfaces/list-inbound-emails.interface.ts
@@ -1,0 +1,26 @@
+import type { PaginationOptions } from '../../../common/interfaces';
+import type { ErrorResponse } from '../../../interfaces';
+import type { GetInboundEmailResponseSuccess } from './get-inbound-email.interface';
+
+export type ListInboundEmailsOptions = PaginationOptions;
+
+export type ListInboundEmail = Omit<
+  GetInboundEmailResponseSuccess,
+  'html' | 'text' | 'headers' | 'object'
+>;
+
+export interface ListInboundEmailsResponseSuccess {
+  object: 'list';
+  has_more: boolean;
+  data: ListInboundEmail[];
+}
+
+export type ListInboundEmailsResponse =
+  | {
+      data: ListInboundEmailsResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/emails/receiving/receiving.ts
+++ b/src/emails/receiving/receiving.ts
@@ -1,8 +1,14 @@
+import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
 import type { Resend } from '../../resend';
 import type {
   GetInboundEmailResponse,
   GetInboundEmailResponseSuccess,
 } from './interfaces/get-inbound-email.interface';
+import type {
+  ListInboundEmailsOptions,
+  ListInboundEmailsResponse,
+  ListInboundEmailsResponseSuccess,
+} from './interfaces/list-inbound-emails.interface';
 
 export class Receiving {
   constructor(private readonly resend: Resend) {}
@@ -11,6 +17,19 @@ export class Receiving {
     const data = await this.resend.get<GetInboundEmailResponseSuccess>(
       `/emails/receiving/${id}`,
     );
+
+    return data;
+  }
+
+  async list(
+    options: ListInboundEmailsOptions = {},
+  ): Promise<ListInboundEmailsResponse> {
+    const queryString = buildPaginationQuery(options);
+    const url = queryString
+      ? `/emails/receiving?${queryString}`
+      : '/emails/receiving';
+
+    const data = await this.resend.get<ListInboundEmailsResponseSuccess>(url);
 
     return data;
   }


### PR DESCRIPTION
This adds a method to list inbound emails through the route `/emails/receiving/:id`. The method is called `resend.emails.receiving.list`.

Note that this PR is made on top of #667 to make the diff easier to read as it builds upon a few types there.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added inbound email listing via GET /emails/receiving, exposed as resend.emails.receiving.list. It supports pagination and returns a lightweight list of messages.

- **New Features**
  - Added Receiving.list(options) with limit, before, and after pagination.
  - Introduced ListInboundEmails interfaces and export; returns object "list", has_more, and minimal email fields.
  - Added tests for empty results, populated lists, and pagination URL building.

- **Bug Fixes**
  - Aligned not_found error message in tests to "Email not found".

<!-- End of auto-generated description by cubic. -->

