### PR TITLE
feat: add pagination for inbound email attachments

### DIFF
--- a/src/attachments/receiving/interfaces/list-attachments.interface.ts
+++ b/src/attachments/receiving/interfaces/list-attachments.interface.ts
@@ -1,12 +1,14 @@
+import type { PaginationOptions } from '../../../common/interfaces';
 import type { ErrorResponse } from '../../../interfaces';
 import type { InboundAttachment } from './attachment';
 
-export interface ListAttachmentsOptions {
+export type ListAttachmentsOptions = PaginationOptions & {
   emailId: string;
-}
+};
 
 export interface ListAttachmentsResponseSuccess {
-  object: 'attachment';
+  object: 'list';
+  has_more: boolean;
   data: InboundAttachment[];
 }
 

--- a/src/attachments/receiving/receiving.ts
+++ b/src/attachments/receiving/receiving.ts
@@ -1,3 +1,4 @@
+import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
 import type { Resend } from '../../resend';
 import type {
   GetAttachmentOptions,
@@ -17,7 +18,7 @@ export class Receiving {
     const { emailId, id } = options;
 
     const data = await this.resend.get<GetAttachmentResponseSuccess>(
-      `/emails/inbound/${emailId}/attachments/${id}`,
+      `/emails/receiving/${emailId}/attachments/${id}`,
     );
 
     return data;
@@ -28,9 +29,12 @@ export class Receiving {
   ): Promise<ListAttachmentsResponse> {
     const { emailId } = options;
 
-    const data = await this.resend.get<ListAttachmentsResponseSuccess>(
-      `/emails/inbound/${emailId}/attachments`,
-    );
+    const queryString = buildPaginationQuery(options);
+    const url = queryString
+      ? `/emails/receiving/${emailId}/attachments?${queryString}`
+      : `/emails/receiving/${emailId}/attachments`;
+
+    const data = await this.resend.get<ListAttachmentsResponseSuccess>(url);
 
     return data;
   }

--- a/src/emails/receiving/receiving.spec.ts
+++ b/src/emails/receiving/receiving.spec.ts
@@ -1,5 +1,9 @@
 import type { ErrorResponse } from '../../interfaces';
 import { Resend } from '../../resend';
+import type {
+  GetInboundEmailResponseSuccess,
+  ListInboundEmailsResponseSuccess,
+} from './interfaces';
 
 const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
@@ -40,7 +44,7 @@ describe('Receiving', () => {
 
     describe('when inbound email found', () => {
       it('returns inbound email', async () => {
-        const apiResponse = {
+        const apiResponse: GetInboundEmailResponseSuccess = {
           object: 'inbound' as const,
           id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
           to: ['received@example.com'],
@@ -117,7 +121,7 @@ describe('Receiving', () => {
       });
 
       it('returns inbound email with no attachments', async () => {
-        const apiResponse = {
+        const apiResponse: GetInboundEmailResponseSuccess = {
           object: 'inbound' as const,
           id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
           to: ['received@example.com'],
@@ -205,7 +209,7 @@ describe('Receiving', () => {
 
     describe('when inbound emails found', () => {
       it('returns list of inbound emails with transformed fields', async () => {
-        const apiResponse = {
+        const apiResponse: ListInboundEmailsResponseSuccess = {
           object: 'list' as const,
           has_more: true,
           data: [
@@ -225,7 +229,6 @@ describe('Receiving', () => {
                   content_type: 'application/pdf',
                   content_id: 'cid_123',
                   content_disposition: 'attachment' as const,
-                  size: 12345,
                 },
               ],
             },
@@ -265,7 +268,6 @@ describe('Receiving', () => {
             "content_type": "application/pdf",
             "filename": "document.pdf",
             "id": "att_123",
-            "size": 12345,
           },
         ],
         "bcc": null,


### PR DESCRIPTION
This PR is the SDK complement to https://github.com/resend/resend-api/pull/2192. It adds pagination to the inbound email attachments.

I also used this opportunity to:

* Update the `object` to `list` for the method that lists attachment (I did that on the API PR too)
* Use the new `/emails/receiving/:emailId/attachments` alias from the API instead of the old `/emails/inbound/:emailId/attachments`
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added pagination for inbound email attachments in the SDK and switched to the new /emails/receiving endpoints. Aligns with PRODUCT-710 to enable cursor-based navigation and reduce large payloads.

- **New Features**
  - attachments.receiving.list now supports limit, before, and after.
  - Uses /emails/receiving/:emailId and /emails/receiving/:emailId/attachments/:id.
  - Builds query params only when pagination options are provided.

- **Migration**
  - List responses now return object: 'list' and has_more. Update any checks relying on the previous object value.

<!-- End of auto-generated description by cubic. -->

