### PR TITLE
feat: get html & text columns for broadcasts

### DIFF
--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -415,6 +415,7 @@ describe('Broadcasts', () => {
         name: 'Announcements',
         audience_id: '78261eea-8f8b-4381-83c6-79fa7120f1cf',
         from: 'Acme <onboarding@resend.dev>',
+        html: '<h1>Hello world</h1>',
         subject: 'hello world',
         reply_to: null,
         preview_text: 'Check out our latest announcements',
@@ -422,6 +423,7 @@ describe('Broadcasts', () => {
         created_at: '2024-12-01T19:32:22.980Z',
         scheduled_at: null,
         sent_at: null,
+        text: 'Hello world',
       };
 
       fetchMock.mockOnce(JSON.stringify(response), {
@@ -442,6 +444,7 @@ describe('Broadcasts', () => {
     "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
     "created_at": "2024-12-01T19:32:22.980Z",
     "from": "Acme <onboarding@resend.dev>",
+    "html": "<h1>Hello world</h1>",
     "id": "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
     "name": "Announcements",
     "object": "broadcast",
@@ -451,6 +454,7 @@ describe('Broadcasts', () => {
     "sent_at": null,
     "status": "draft",
     "subject": "hello world",
+    "text": "Hello world",
   },
   "error": null,
 }

--- a/src/broadcasts/interfaces/broadcast.ts
+++ b/src/broadcasts/interfaces/broadcast.ts
@@ -10,4 +10,6 @@ export interface Broadcast {
   created_at: string;
   scheduled_at: string | null;
   sent_at: string | null;
+  html: string | null;
+  text: string | null;
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Expose html and text fields on Broadcast so clients can read a broadcast’s HTML and plain-text content. This is backward-compatible and only adds two nullable fields.

- **New Features**
  - Added html and text (nullable strings) to Broadcast interface.
  - Updated tests to expect html and text in the broadcast response.

<!-- End of auto-generated description by cubic. -->

