### PR TITLE
fix: repo urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/resendlabs/resend-node.git"
+    "url": "git+https://github.com/resend/resend-node.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/resendlabs/resend-node/issues"
+    "url": "https://github.com/resend/resend-node/issues"
   },
-  "homepage": "https://github.com/resendlabs/resend-node#readme",
+  "homepage": "https://github.com/resend/resend-node#readme",
   "peerDependencies": {
     "@react-email/render": "*"
   },

--- a/readme.md
+++ b/readme.md
@@ -36,10 +36,10 @@ yarn add resend
 
 Send email with:
 
-- [Node.js](https://github.com/resendlabs/resend-node-example)
-- [Next.js (App Router)](https://github.com/resendlabs/resend-nextjs-app-router-example)
-- [Next.js (Pages Router)](https://github.com/resendlabs/resend-nextjs-pages-router-example)
-- [Express](https://github.com/resendlabs/resend-express-example)
+- [Node.js](https://github.com/resend/resend-node-example)
+- [Next.js (App Router)](https://github.com/resend/resend-nextjs-app-router-example)
+- [Next.js (Pages Router)](https://github.com/resend/resend-nextjs-pages-router-example)
+- [Express](https://github.com/resend/resend-express-example)
 
 ## Setup
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix broken GitHub links by updating all repo URLs from resendlabs to resend in package metadata and README.

- **Bug Fixes**
  - package.json: repository.url, bugs.url, and homepage now point to github.com/resend/resend-node.
  - README: example links updated to github.com/resend/* repositories.

<!-- End of auto-generated description by cubic. -->

