### PR TITLE
feat: new 'suspended_api_key' in error name type

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,21 +1,24 @@
-export type RESEND_ERROR_CODE_KEY =
-  | 'missing_required_field'
-  | 'invalid_idempotency_key'
-  | 'invalid_idempotent_request'
-  | 'concurrent_idempotent_requests'
-  | 'invalid_access'
-  | 'invalid_parameter'
-  | 'invalid_region'
-  | 'rate_limit_exceeded'
-  | 'missing_api_key'
-  | 'invalid_api_key'
-  | 'suspended_api_key'
-  | 'invalid_from_address'
-  | 'validation_error'
-  | 'not_found'
-  | 'method_not_allowed'
-  | 'application_error'
-  | 'internal_server_error';
+export const RESEND_ERROR_CODES_BY_KEY = {
+  missing_required_field: 422,
+  invalid_idempotency_key: 400,
+  invalid_idempotent_request: 409,
+  concurrent_idempotent_requests: 409,
+  invalid_access: 422,
+  invalid_parameter: 422,
+  invalid_region: 422,
+  rate_limit_exceeded: 429,
+  missing_api_key: 401,
+  invalid_api_key: 403,
+  suspended_api_key: 403,
+  invalid_from_address: 403,
+  validation_error: 403,
+  not_found: 404,
+  method_not_allowed: 405,
+  application_error: 500,
+  internal_server_error: 500,
+} as const;
+
+export type RESEND_ERROR_CODE_KEY = keyof typeof RESEND_ERROR_CODES_BY_KEY;
 
 export interface ErrorResponse {
   message: string;


### PR DESCRIPTION
Adds in the new `suspended_api_key` error name to the type union of the possible error names that the API can respond with. 

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added 'suspended_api_key' to the RESEND_ERROR_CODE_KEY union so suspended API key errors are typed correctly. Removed the unused RESEND_ERROR_CODES_BY_KEY status code map.

<!-- End of auto-generated description by cubic. -->

