### PR TITLE
chore: bump to 6.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Merging into main so this doesn't mess up the versioning we have in canary.