### PR TITLE
feat: avoid downloading attachments ourselves

### DIFF
--- a/src/attachments/receiving/interfaces/attachment.ts
+++ b/src/attachments/receiving/interfaces/attachment.ts
@@ -4,15 +4,6 @@ export interface InboundAttachment {
   content_type: string;
   content_disposition: 'inline' | 'attachment';
   content_id?: string;
-  content: string; // base64
-}
-
-export interface ApiInboundAttachment {
-  id: string;
-  filename?: string;
-  content_type: string;
-  content_disposition: 'inline' | 'attachment';
-  content_id?: string;
   download_url: string;
   expires_at: string;
 }

--- a/src/attachments/receiving/interfaces/get-attachment.interface.ts
+++ b/src/attachments/receiving/interfaces/get-attachment.interface.ts
@@ -1,14 +1,9 @@
 import type { ErrorResponse } from '../../../interfaces';
-import type { ApiInboundAttachment, InboundAttachment } from './attachment';
+import type { InboundAttachment } from './attachment';
 
 export interface GetAttachmentOptions {
   emailId: string;
   id: string;
-}
-
-export interface GetAttachmentApiResponse {
-  object: 'attachment';
-  data: ApiInboundAttachment;
 }
 
 export interface GetAttachmentResponseSuccess {

--- a/src/attachments/receiving/receiving.spec.ts
+++ b/src/attachments/receiving/receiving.spec.ts
@@ -12,18 +12,6 @@ fetchMocker.enableMocks();
 
 const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
-const pdfContent = 'PDF document content';
-const pdfBuffer = Buffer.from(pdfContent);
-const pdfBase64 = pdfBuffer.toString('base64');
-
-const imageContent = 'PNG image data';
-const imageBuffer = Buffer.from(imageContent);
-const imageBase64 = imageBuffer.toString('base64');
-
-const textContent = 'Plain text content';
-const textBuffer = Buffer.from(textContent);
-const textBase64 = textBuffer.toString('base64');
-
 describe('Receiving', () => {
   afterEach(() => fetchMock.resetMocks());
   afterAll(() => fetchMocker.disableMocks());
@@ -62,7 +50,7 @@ describe('Receiving', () => {
     });
 
     describe('when attachment found', () => {
-      it('returns attachment with transformed fields', async () => {
+      it('returns attachment with download URL', async () => {
         const apiResponse = {
           object: 'attachment' as const,
           data: {
@@ -72,6 +60,7 @@ describe('Receiving', () => {
             content_id: 'cid_123',
             content_disposition: 'attachment' as const,
             download_url: 'https://example.com/download/att_123',
+            expires_at: '2025-10-18T12:00:00Z',
           },
         };
 
@@ -87,14 +76,6 @@ describe('Receiving', () => {
           },
         );
 
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_123',
-          async () =>
-            new Response(pdfBuffer, {
-              status: 200,
-            }),
-        );
-
         const result = await resend.attachments.receiving.get({
           emailId: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
           id: 'att_123',
@@ -103,10 +84,11 @@ describe('Receiving', () => {
         expect(result).toEqual({
           data: {
             data: {
-              content: pdfBase64,
               content_disposition: 'attachment',
               content_id: 'cid_123',
               content_type: 'application/pdf',
+              download_url: 'https://example.com/download/att_123',
+              expires_at: '2025-10-18T12:00:00Z',
               filename: 'document.pdf',
               id: 'att_123',
             },
@@ -116,7 +98,7 @@ describe('Receiving', () => {
         });
       });
 
-      it('returns inline attachment', async () => {
+      it('returns inline attachment with download URL', async () => {
         const apiResponse = {
           object: 'attachment' as const,
           data: {
@@ -126,6 +108,7 @@ describe('Receiving', () => {
             content_id: 'cid_456',
             content_disposition: 'inline' as const,
             download_url: 'https://example.com/download/att_456',
+            expires_at: '2025-10-18T12:00:00Z',
           },
         };
 
@@ -141,14 +124,6 @@ describe('Receiving', () => {
           },
         );
 
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_456',
-          async () =>
-            new Response(imageBuffer, {
-              status: 200,
-            }),
-        );
-
         const result = await resend.attachments.receiving.get({
           emailId: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
           id: 'att_456',
@@ -157,10 +132,11 @@ describe('Receiving', () => {
         expect(result).toEqual({
           data: {
             data: {
-              content: imageBase64,
               content_disposition: 'inline',
               content_id: 'cid_456',
               content_type: 'image/png',
+              download_url: 'https://example.com/download/att_456',
+              expires_at: '2025-10-18T12:00:00Z',
               filename: 'image.png',
               id: 'att_456',
             },
@@ -179,6 +155,7 @@ describe('Receiving', () => {
             content_type: 'text/plain',
             content_disposition: 'attachment' as const,
             download_url: 'https://example.com/download/att_789',
+            expires_at: '2025-10-18T12:00:00Z',
             // Optional fields (filename, content_id) omitted
           },
         };
@@ -195,14 +172,6 @@ describe('Receiving', () => {
           },
         );
 
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_789',
-          async () =>
-            new Response(textBuffer, {
-              status: 200,
-            }),
-        );
-
         const result = await resend.attachments.receiving.get({
           emailId: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
           id: 'att_789',
@@ -211,9 +180,10 @@ describe('Receiving', () => {
         expect(result).toEqual({
           data: {
             data: {
-              content: textBase64,
               content_disposition: 'attachment',
               content_type: 'text/plain',
+              download_url: 'https://example.com/download/att_789',
+              expires_at: '2025-10-18T12:00:00Z',
               id: 'att_789',
             },
             object: 'attachment',
@@ -236,6 +206,7 @@ describe('Receiving', () => {
           content_id: 'cid_123',
           content_disposition: 'attachment' as const,
           download_url: 'https://example.com/download/att_123',
+          expires_at: '2025-10-18T12:00:00Z',
         },
         {
           id: 'att_456',
@@ -244,6 +215,7 @@ describe('Receiving', () => {
           content_id: 'cid_456',
           content_disposition: 'inline' as const,
           download_url: 'https://example.com/download/att_456',
+          expires_at: '2025-10-18T12:00:00Z',
         },
       ],
     };
@@ -276,7 +248,7 @@ describe('Receiving', () => {
     });
 
     describe('when attachments found', () => {
-      it('returns multiple attachments', async () => {
+      it('returns multiple attachments with download URLs', async () => {
         fetchMock.mockOnceIf(
           'https://api.resend.com/emails/receiving/67d9bcdb-5a02-42d7-8da9-0d6feea18cff/attachments',
           JSON.stringify(apiResponse),
@@ -287,21 +259,6 @@ describe('Receiving', () => {
               Authorization: 'Bearer re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
             },
           },
-        );
-
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_123',
-          async () =>
-            new Response(pdfBuffer, {
-              status: 200,
-            }),
-        );
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_456',
-          async () =>
-            new Response(imageBuffer, {
-              status: 200,
-            }),
         );
 
         const result = await resend.attachments.receiving.list({
@@ -318,7 +275,8 @@ describe('Receiving', () => {
               content_type: 'application/pdf',
               content_id: 'cid_123',
               content_disposition: 'attachment',
-              content: pdfBase64,
+              download_url: 'https://example.com/download/att_123',
+              expires_at: '2025-10-18T12:00:00Z',
             },
             {
               id: 'att_456',
@@ -326,7 +284,8 @@ describe('Receiving', () => {
               content_type: 'image/png',
               content_id: 'cid_456',
               content_disposition: 'inline',
-              content: imageBase64,
+              download_url: 'https://example.com/download/att_456',
+              expires_at: '2025-10-18T12:00:00Z',
             },
           ],
         };
@@ -367,21 +326,6 @@ describe('Receiving', () => {
           headers,
         });
 
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_123',
-          async () =>
-            new Response(pdfBuffer, {
-              status: 200,
-            }),
-        );
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_456',
-          async () =>
-            new Response(imageBuffer, {
-              status: 200,
-            }),
-        );
-
         const result = await resend.attachments.receiving.list({
           emailId: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
         });
@@ -396,7 +340,8 @@ describe('Receiving', () => {
               content_type: 'application/pdf',
               content_id: 'cid_123',
               content_disposition: 'attachment',
-              content: pdfBase64,
+              download_url: 'https://example.com/download/att_123',
+              expires_at: '2025-10-18T12:00:00Z',
             },
             {
               id: 'att_456',
@@ -404,7 +349,8 @@ describe('Receiving', () => {
               content_type: 'image/png',
               content_id: 'cid_456',
               content_disposition: 'inline',
-              content: imageBase64,
+              download_url: 'https://example.com/download/att_456',
+              expires_at: '2025-10-18T12:00:00Z',
             },
           ],
         };
@@ -423,21 +369,6 @@ describe('Receiving', () => {
       it('calls endpoint passing limit param and return the response', async () => {
         mockSuccessResponse(apiResponse, { headers });
 
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_123',
-          async () =>
-            new Response(pdfBuffer, {
-              status: 200,
-            }),
-        );
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_456',
-          async () =>
-            new Response(imageBuffer, {
-              status: 200,
-            }),
-        );
-
         const result = await resend.attachments.receiving.list({
           emailId: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
           limit: 10,
@@ -453,7 +384,8 @@ describe('Receiving', () => {
               content_type: 'application/pdf',
               content_id: 'cid_123',
               content_disposition: 'attachment',
-              content: pdfBase64,
+              download_url: 'https://example.com/download/att_123',
+              expires_at: '2025-10-18T12:00:00Z',
             },
             {
               id: 'att_456',
@@ -461,7 +393,8 @@ describe('Receiving', () => {
               content_type: 'image/png',
               content_id: 'cid_456',
               content_disposition: 'inline',
-              content: imageBase64,
+              download_url: 'https://example.com/download/att_456',
+              expires_at: '2025-10-18T12:00:00Z',
             },
           ],
         };
@@ -478,21 +411,6 @@ describe('Receiving', () => {
       it('calls endpoint passing after param and return the response', async () => {
         mockSuccessResponse(apiResponse, { headers });
 
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_123',
-          async () =>
-            new Response(pdfBuffer, {
-              status: 200,
-            }),
-        );
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_456',
-          async () =>
-            new Response(imageBuffer, {
-              status: 200,
-            }),
-        );
-
         const result = await resend.attachments.receiving.list({
           emailId: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
           after: 'cursor123',
@@ -508,7 +426,8 @@ describe('Receiving', () => {
               content_type: 'application/pdf',
               content_id: 'cid_123',
               content_disposition: 'attachment',
-              content: pdfBase64,
+              download_url: 'https://example.com/download/att_123',
+              expires_at: '2025-10-18T12:00:00Z',
             },
             {
               id: 'att_456',
@@ -516,7 +435,8 @@ describe('Receiving', () => {
               content_type: 'image/png',
               content_id: 'cid_456',
               content_disposition: 'inline',
-              content: imageBase64,
+              download_url: 'https://example.com/download/att_456',
+              expires_at: '2025-10-18T12:00:00Z',
             },
           ],
         };
@@ -533,21 +453,6 @@ describe('Receiving', () => {
       it('calls endpoint passing before param and return the response', async () => {
         mockSuccessResponse(apiResponse, { headers });
 
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_123',
-          async () =>
-            new Response(pdfBuffer, {
-              status: 200,
-            }),
-        );
-        fetchMock.mockOnceIf(
-          'https://example.com/download/att_456',
-          async () =>
-            new Response(imageBuffer, {
-              status: 200,
-            }),
-        );
-
         const result = await resend.attachments.receiving.list({
           emailId: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
           before: 'cursor123',
@@ -563,7 +468,8 @@ describe('Receiving', () => {
               content_type: 'application/pdf',
               content_id: 'cid_123',
               content_disposition: 'attachment',
-              content: pdfBase64,
+              download_url: 'https://example.com/download/att_123',
+              expires_at: '2025-10-18T12:00:00Z',
             },
             {
               id: 'att_456',
@@ -571,7 +477,8 @@ describe('Receiving', () => {
               content_type: 'image/png',
               content_id: 'cid_456',
               content_disposition: 'inline',
-              content: imageBase64,
+              download_url: 'https://example.com/download/att_456',
+              expires_at: '2025-10-18T12:00:00Z',
             },
           ],
         };

--- a/src/attachments/receiving/receiving.ts
+++ b/src/attachments/receiving/receiving.ts
@@ -1,7 +1,6 @@
 import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
 import type { Resend } from '../../resend';
 import type {
-  GetAttachmentApiResponse,
   GetAttachmentOptions,
   GetAttachmentResponse,
   GetAttachmentResponseSuccess,
@@ -12,84 +11,17 @@ import type {
   ListAttachmentsResponse,
 } from './interfaces/list-attachments.interface';
 
-type DownloadAttachmentResult =
-  | {
-      type: 'error';
-      message: string;
-    }
-  | {
-      type: 'success';
-      base64Content: string;
-    };
-
 export class Receiving {
   constructor(private readonly resend: Resend) {}
-
-  private async downloadAttachment(
-    url: string,
-  ): Promise<DownloadAttachmentResult> {
-    try {
-      const content = await fetch(url);
-      if (!content.ok) {
-        return {
-          type: 'error',
-          message: 'Failed to download attachment content',
-        };
-      }
-
-      const arrayBuffer = await content.arrayBuffer();
-      const buffer = Buffer.from(arrayBuffer);
-      return {
-        type: 'success',
-        base64Content: buffer.toString('base64'),
-      };
-    } catch {
-      return {
-        type: 'error',
-        message: 'An error occurred while downloading attachment content',
-      };
-    }
-  }
 
   async get(options: GetAttachmentOptions): Promise<GetAttachmentResponse> {
     const { emailId, id } = options;
 
-    const apiResponse = await this.resend.get<GetAttachmentApiResponse>(
+    const data = await this.resend.get<GetAttachmentResponseSuccess>(
       `/emails/receiving/${emailId}/attachments/${id}`,
     );
 
-    if ('error' in apiResponse && apiResponse.error) {
-      return apiResponse;
-    }
-
-    const {
-      expires_at: _expires_at,
-      download_url,
-      ...otherFields
-    } = apiResponse.data.data;
-    const downloadResult = await this.downloadAttachment(download_url);
-    if (downloadResult.type === 'error') {
-      return {
-        data: null,
-        error: {
-          name: 'application_error',
-          message: downloadResult.message,
-        },
-      };
-    }
-
-    const responseData: GetAttachmentResponseSuccess = {
-      object: 'attachment',
-      data: {
-        ...otherFields,
-        content: downloadResult.base64Content,
-      },
-    };
-
-    return {
-      data: responseData,
-      error: null,
-    };
+    return data;
   }
 
   async list(
@@ -102,43 +34,8 @@ export class Receiving {
       ? `/emails/receiving/${emailId}/attachments?${queryString}`
       : `/emails/receiving/${emailId}/attachments`;
 
-    const apiResponse = await this.resend.get<ListAttachmentsApiResponse>(url);
+    const data = await this.resend.get<ListAttachmentsApiResponse>(url);
 
-    if ('error' in apiResponse && apiResponse.error) {
-      return apiResponse;
-    }
-
-    const attachmentsWithContent = [];
-    for (const attachment of apiResponse.data.data) {
-      const {
-        expires_at: _expires_at,
-        download_url,
-        ...otherFields
-      } = attachment;
-      const downloadResult = await this.downloadAttachment(download_url);
-      if (downloadResult.type === 'error') {
-        return {
-          data: null,
-          error: {
-            name: 'application_error',
-            message: downloadResult.message,
-          },
-        };
-      }
-
-      attachmentsWithContent.push({
-        ...otherFields,
-        content: downloadResult.base64Content,
-      });
-    }
-
-    return {
-      data: {
-        object: 'list',
-        has_more: apiResponse.data.has_more,
-        data: attachmentsWithContent,
-      },
-      error: null,
-    };
+    return data;
   }
 }


### PR DESCRIPTION
We discussed on our daily yesterday that downloading files on behalf of our users limits their capabilities to use them as Buffers without extra work as it's probably not the majority of users that will want to use them as base64 directly.

We can eventually discuss a `download` method or something along those lines.