### PR TITLE
chore: bump to canary 6.3.0-canary.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.3.0-canary.0",
+  "version": "6.3.0-canary.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Let's make a release of the `6.3.0-canary.1` with the new webhook verification and not downloading attachments ourselves.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Release 6.3.0-canary.1 to ship webhook verification and stop downloading attachments in the SDK. This improves security and reduces network overhead.

<!-- End of auto-generated description by cubic. -->

