### PR TITLE
feat: add sdk methods for webhooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export * from './emails/receiving/interfaces';
 export { ErrorResponse } from './interfaces';
 export { Resend } from './resend';
 export * from './segments/interfaces';
+export * from './webhooks/interfaces';

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -41,7 +41,7 @@ export class Resend {
   readonly contacts = new Contacts(this);
   readonly domains = new Domains(this);
   readonly emails = new Emails(this);
-  readonly webhooks = new Webhooks();
+  readonly webhooks = new Webhooks(this);
   readonly templates = new Templates(this);
   readonly topics = new Topics(this);
 

--- a/src/webhooks/interfaces/create-webhook-options.interface.ts
+++ b/src/webhooks/interfaces/create-webhook-options.interface.ts
@@ -1,0 +1,24 @@
+import type { PostOptions } from '../../common/interfaces';
+import type { ErrorResponse } from '../../interfaces';
+
+export interface CreateWebhookOptions {
+  endpoint: string;
+  events: string[];
+}
+
+export interface CreateWebhookRequestOptions extends PostOptions {}
+
+export interface CreateWebhookResponseSuccess {
+  object: 'webhook';
+  id: string;
+}
+
+export type CreateWebhookResponse =
+  | {
+      data: CreateWebhookResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/webhooks/interfaces/get-webhook.interface.ts
+++ b/src/webhooks/interfaces/get-webhook.interface.ts
@@ -1,0 +1,20 @@
+import type { ErrorResponse } from '../../interfaces';
+
+export interface GetWebhookResponseSuccess {
+  object: 'webhook';
+  id: string;
+  created_at: string;
+  status: string;
+  endpoint: string;
+  events: string[] | null;
+}
+
+export type GetWebhookResponse =
+  | {
+      data: GetWebhookResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/webhooks/interfaces/index.ts
+++ b/src/webhooks/interfaces/index.ts
@@ -1,0 +1,16 @@
+export type {
+  CreateWebhookOptions,
+  CreateWebhookRequestOptions,
+  CreateWebhookResponse,
+  CreateWebhookResponseSuccess,
+} from './create-webhook-options.interface';
+export type {
+  GetWebhookResponse,
+  GetWebhookResponseSuccess,
+} from './get-webhook.interface';
+export type {
+  ListWebhooksOptions,
+  ListWebhooksResponse,
+  ListWebhooksResponseSuccess,
+  Webhook,
+} from './list-webhooks.interface';

--- a/src/webhooks/interfaces/list-webhooks.interface.ts
+++ b/src/webhooks/interfaces/list-webhooks.interface.ts
@@ -1,0 +1,28 @@
+import type { PaginationOptions } from '../../common/interfaces';
+import type { ErrorResponse } from '../../interfaces';
+
+export type ListWebhooksOptions = PaginationOptions;
+
+export interface Webhook {
+  id: string;
+  endpoint: string;
+  created_at: string;
+  status: string;
+  events: string[] | null;
+}
+
+export type ListWebhooksResponseSuccess = {
+  object: 'list';
+  has_more: boolean;
+  data: Webhook[];
+};
+
+export type ListWebhooksResponse =
+  | {
+      data: ListWebhooksResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -1,6 +1,15 @@
 import { Webhook } from 'svix';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Webhooks } from './webhooks';
+import createFetchMock from 'vitest-fetch-mock';
+import type { ErrorResponse } from '../interfaces';
+import { Resend } from '../resend';
+import { mockSuccessResponse } from '../test-utils/mock-fetch';
+import type {
+  CreateWebhookOptions,
+  CreateWebhookResponseSuccess,
+} from './interfaces/create-webhook-options.interface';
+import type { GetWebhookResponseSuccess } from './interfaces/get-webhook.interface';
+import type { ListWebhooksResponseSuccess } from './interfaces/list-webhooks.interface';
 
 const mocks = vi.hoisted(() => {
   const verify = vi.fn();
@@ -18,34 +27,222 @@ vi.mock('svix', () => ({
   Webhook: mocks.webhookConstructor,
 }));
 
+const fetchMocker = createFetchMock(vi);
+fetchMocker.enableMocks();
+
 describe('Webhooks', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.verify.mockReset();
+    fetchMock.resetMocks();
   });
 
-  it('verifies payload using svix headers', () => {
-    const options = {
-      payload: '{"type":"email.sent"}',
-      headers: {
-        id: 'msg_123',
-        timestamp: '1713984875',
-        signature: 'v1,some-signature',
-      },
-      webhookSecret: 'whsec_123',
+  afterAll(() => fetchMocker.disableMocks());
+
+  describe('create', () => {
+    it('creates a webhook', async () => {
+      const payload: CreateWebhookOptions = {
+        endpoint: 'https://example.com/webhook',
+        events: ['email.sent', 'email.delivered'],
+      };
+      const response: CreateWebhookResponseSuccess = {
+        object: 'webhook',
+        id: '430eed87-632a-4ea6-90db-0aace67ec228',
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 201,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(
+        resend.webhooks.create(payload),
+      ).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "id": "430eed87-632a-4ea6-90db-0aace67ec228",
+    "object": "webhook",
+  },
+  "error": null,
+}
+`);
+    });
+  });
+
+  describe('get', () => {
+    describe('when webhook not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          message: 'Webhook endpoint not found',
+          statusCode: 404,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.webhooks.get('1234');
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Webhook endpoint not found",
+    "name": "not_found",
+    "statusCode": 404,
+  },
+}
+`);
+      });
+    });
+
+    it('gets a webhook', async () => {
+      const response: GetWebhookResponseSuccess = {
+        object: 'webhook',
+        id: '430eed87-632a-4ea6-90db-0aace67ec228',
+        created_at: '2023-06-21T06:10:36.144Z',
+        status: 'enabled',
+        endpoint: 'https://example.com/webhook',
+        events: ['email.sent', 'email.delivered'],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(resend.webhooks.get('1234')).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "created_at": "2023-06-21T06:10:36.144Z",
+    "endpoint": "https://example.com/webhook",
+    "events": [
+      "email.sent",
+      "email.delivered",
+    ],
+    "id": "430eed87-632a-4ea6-90db-0aace67ec228",
+    "object": "webhook",
+    "status": "enabled",
+  },
+  "error": null,
+}
+`);
+    });
+  });
+
+  describe('list', () => {
+    const response: ListWebhooksResponseSuccess = {
+      has_more: false,
+      object: 'list',
+      data: [
+        {
+          id: '430eed87-632a-4ea6-90db-0aace67ec228',
+          endpoint: 'https://example.com/webhook',
+          created_at: '2023-06-21T06:10:36.144Z',
+          status: 'enabled',
+          events: ['email.sent', 'email.delivered'],
+        },
+        {
+          id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+          endpoint: 'https://example.com/webhook2',
+          created_at: '2023-06-20T06:10:36.144Z',
+          status: 'enabled',
+          events: ['email.bounced'],
+        },
+      ],
     };
 
-    const expectedResult = { id: 'msg_123', status: 'verified' };
-    mocks.verify.mockReturnValue(expectedResult);
+    describe('when no pagination options are provided', () => {
+      it('lists webhooks', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
 
-    const result = new Webhooks().verify(options);
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
-    expect(Webhook).toHaveBeenCalledWith(options.webhookSecret);
-    expect(mocks.verify).toHaveBeenCalledWith(options.payload, {
-      'svix-id': options.headers.id,
-      'svix-timestamp': options.headers.timestamp,
-      'svix-signature': options.headers.signature,
+        const result = await resend.webhooks.list();
+        expect(result).toEqual({
+          data: response,
+          error: null,
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/webhooks',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
     });
-    expect(result).toBe(expectedResult);
+
+    describe('when pagination options are provided', () => {
+      it('passes limit param and returns a response', async () => {
+        mockSuccessResponse(response, {
+          headers: { Authorization: 'Bearer re_924b3rjh2387fbewf823' },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = await resend.webhooks.list({ limit: 10 });
+        expect(result).toEqual({
+          data: response,
+          error: null,
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://api.resend.com/webhooks?limit=10',
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.any(Headers),
+          }),
+        );
+      });
+    });
+  });
+
+  describe('verify', () => {
+    it('verifies payload using svix headers', () => {
+      const options = {
+        payload: '{"type":"email.sent"}',
+        headers: {
+          id: 'msg_123',
+          timestamp: '1713984875',
+          signature: 'v1,some-signature',
+        },
+        webhookSecret: 'whsec_123',
+      };
+
+      const expectedResult = { id: 'msg_123', status: 'verified' };
+      mocks.verify.mockReturnValue(expectedResult);
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const result = resend.webhooks.verify(options);
+
+      expect(Webhook).toHaveBeenCalledWith(options.webhookSecret);
+      expect(mocks.verify).toHaveBeenCalledWith(options.payload, {
+        'svix-id': options.headers.id,
+        'svix-timestamp': options.headers.timestamp,
+        'svix-signature': options.headers.signature,
+      });
+      expect(result).toBe(expectedResult);
+    });
   });
 });

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -1,4 +1,21 @@
 import { Webhook } from 'svix';
+import { buildPaginationQuery } from '../common/utils/build-pagination-query';
+import type { Resend } from '../resend';
+import type {
+  CreateWebhookOptions,
+  CreateWebhookRequestOptions,
+  CreateWebhookResponse,
+  CreateWebhookResponseSuccess,
+} from './interfaces/create-webhook-options.interface';
+import type {
+  GetWebhookResponse,
+  GetWebhookResponseSuccess,
+} from './interfaces/get-webhook.interface';
+import type {
+  ListWebhooksOptions,
+  ListWebhooksResponse,
+  ListWebhooksResponseSuccess,
+} from './interfaces/list-webhooks.interface';
 
 interface Headers {
   id: string;
@@ -13,6 +30,36 @@ interface VerifyWebhookOptions {
 }
 
 export class Webhooks {
+  constructor(private readonly resend: Resend) {}
+
+  async create(
+    payload: CreateWebhookOptions,
+    options: CreateWebhookRequestOptions = {},
+  ): Promise<CreateWebhookResponse> {
+    const data = await this.resend.post<CreateWebhookResponseSuccess>(
+      '/webhooks',
+      payload,
+      options,
+    );
+    return data;
+  }
+
+  async get(id: string): Promise<GetWebhookResponse> {
+    const data = await this.resend.get<GetWebhookResponseSuccess>(
+      `/webhooks/${id}`,
+    );
+
+    return data;
+  }
+
+  async list(options: ListWebhooksOptions = {}): Promise<ListWebhooksResponse> {
+    const queryString = buildPaginationQuery(options);
+    const url = queryString ? `/webhooks?${queryString}` : '/webhooks';
+
+    const data = await this.resend.get<ListWebhooksResponseSuccess>(url);
+    return data;
+  }
+
   verify(payload: VerifyWebhookOptions) {
     const webhook = new Webhook(payload.webhookSecret);
     return webhook.verify(payload.payload, {


### PR DESCRIPTION
This adds the following methods to our SDK:

* Creating webhooks (`POST /webhooks`)
* Getting a webhook (`GET /webhook/:id`)
* Listing webhooks (`GET /webhooks`)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds SDK support for managing webhooks. You can now create, get, and list webhooks via Resend.webhooks, addressing PRODUCT-807.

- **New Features**
  - webhooks.create({ endpoint, events }, options) → POST /webhooks
  - webhooks.get(id) → GET /webhooks/:id
  - webhooks.list({ limit, before, after }) → GET /webhooks with pagination
  - Exposes typed interfaces for options and responses

<!-- End of auto-generated description by cubic. -->

