### PR TITLE
feat: add size to attachment response

### DIFF
--- a/src/attachments/receiving/interfaces/attachment.ts
+++ b/src/attachments/receiving/interfaces/attachment.ts
@@ -1,6 +1,7 @@
 export interface InboundAttachment {
   id: string;
   filename?: string;
+  size: number;
   content_type: string;
   content_disposition: 'inline' | 'attachment';
   content_id?: string;

--- a/src/attachments/receiving/interfaces/list-attachments.interface.ts
+++ b/src/attachments/receiving/interfaces/list-attachments.interface.ts
@@ -9,15 +9,7 @@ export type ListAttachmentsOptions = PaginationOptions & {
 export interface ListAttachmentsApiResponse {
   object: 'list';
   has_more: boolean;
-  data: Array<{
-    id: string;
-    filename?: string;
-    content_type: string;
-    content_disposition: 'inline' | 'attachment';
-    content_id?: string;
-    download_url: string;
-    expires_at: string;
-  }>;
+  data: InboundAttachment[];
 }
 
 export interface ListAttachmentsResponseSuccess {

--- a/src/emails/receiving/interfaces/get-inbound-email.interface.ts
+++ b/src/emails/receiving/interfaces/get-inbound-email.interface.ts
@@ -16,6 +16,7 @@ export interface GetInboundEmailResponseSuccess {
   attachments: Array<{
     id: string;
     filename: string;
+    size: number;
     content_type: string;
     content_id: string;
     content_disposition: string;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added attachment size to inbound email and attachment list responses. This lets clients display file size and enforce limits.

- **New Features**
  - Added size: number to InboundAttachment and to GetInboundEmail attachments.

- **Refactors**
  - Standardized ListAttachmentsApiResponse.data to use InboundAttachment[] for consistent typing.

<!-- End of auto-generated description by cubic. -->

