### PR TITLE
feat: add message_id to inbound email response

### DIFF
--- a/src/emails/receiving/interfaces/get-inbound-email.interface.ts
+++ b/src/emails/receiving/interfaces/get-inbound-email.interface.ts
@@ -13,6 +13,7 @@ export interface GetInboundEmailResponseSuccess {
   html: string | null;
   text: string | null;
   headers: Record<string, string>;
+  message_id: string;
   attachments: Array<{
     id: string;
     filename: string;


### PR DESCRIPTION
API does return this field.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add message_id to the inbound email response interface to match the API. Enables clients to use Message-ID for threading and deduping.

- **Migration**
  - Update any mocks/fixtures of GetInboundEmailResponseSuccess to include message_id (string).

<!-- End of auto-generated description by cubic. -->

