### PR TITLE
fix: create topics default subscription

### DIFF
--- a/src/topics/topics.ts
+++ b/src/topics/topics.ts
@@ -30,7 +30,7 @@ export class Topics {
 
     const data = await this.resend.post<CreateTopicResponseSuccess>('/topics', {
       ...body,
-      defaultSubscription: defaultSubscription,
+      default_subscription: defaultSubscription,
     });
 
     return data;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes topic creation in the Node SDK by mapping defaultSubscription to default_subscription in the API request. Resolves the 422 “Missing default_subscription” error and aligns with Linear PRODUCT-939.

- **Bug Fixes**
  - POST /topics now sends default_subscription using the provided defaultSubscription value.

<!-- End of auto-generated description by cubic. -->

