### PR TITLE
fix: contact topics list should return a normal paginated list

### DIFF
--- a/src/contacts/topics/contact-topics.spec.ts
+++ b/src/contacts/topics/contact-topics.spec.ts
@@ -2,9 +2,9 @@ import createFetchMock from 'vitest-fetch-mock';
 import { Resend } from '../../resend';
 import { mockSuccessResponse } from '../../test-utils/mock-fetch';
 import type {
-  GetContactTopicsOptions,
-  GetContactTopicsResponseSuccess,
-} from './interfaces/get-contact-topics.interface';
+  ListContactTopicsOptions,
+  ListContactTopicsResponseSuccess,
+} from './interfaces/list-contact-topics.interface';
 import type {
   UpdateContactTopicsOptions,
   UpdateContactTopicsResponseSuccess,
@@ -174,31 +174,28 @@ describe('ContactTopics', () => {
     });
   });
 
-  describe('get', () => {
+  describe('list', () => {
     it('gets contact topics by email', async () => {
-      const options: GetContactTopicsOptions = {
+      const options: ListContactTopicsOptions = {
         email: 'carolina@resend.com',
       };
-      const response: GetContactTopicsResponseSuccess = {
+      const response: ListContactTopicsResponseSuccess = {
         has_more: false,
         object: 'list',
-        data: {
-          email: 'carolina@resend.com',
-          topics: [
-            {
-              id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
-              name: 'Test Topic',
-              description: 'This is a test topic',
-              subscription: 'opt_in',
-            },
-            {
-              id: 'another-topic-id',
-              name: 'Another Topic',
-              description: null,
-              subscription: 'opt_out',
-            },
-          ],
-        },
+        data: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            name: 'Test Topic',
+            description: 'This is a test topic',
+            subscription: 'opt_in',
+          },
+          {
+            id: 'another-topic-id',
+            name: 'Another Topic',
+            description: null,
+            subscription: 'opt_out',
+          },
+        ],
       };
 
       mockSuccessResponse(response, {
@@ -207,27 +204,24 @@ describe('ContactTopics', () => {
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
       await expect(
-        resend.contacts.topics.get(options),
+        resend.contacts.topics.list(options),
       ).resolves.toMatchInlineSnapshot(`
 {
   "data": {
-    "data": {
-      "email": "carolina@resend.com",
-      "topics": [
-        {
-          "description": "This is a test topic",
-          "id": "c7e1e488-ae2c-4255-a40c-a4db3af7ed0b",
-          "name": "Test Topic",
-          "subscription": "opt_in",
-        },
-        {
-          "description": null,
-          "id": "another-topic-id",
-          "name": "Another Topic",
-          "subscription": "opt_out",
-        },
-      ],
-    },
+    "data": [
+      {
+        "description": "This is a test topic",
+        "id": "c7e1e488-ae2c-4255-a40c-a4db3af7ed0b",
+        "name": "Test Topic",
+        "subscription": "opt_in",
+      },
+      {
+        "description": null,
+        "id": "another-topic-id",
+        "name": "Another Topic",
+        "subscription": "opt_out",
+      },
+    ],
     "has_more": false,
     "object": "list",
   },
@@ -237,23 +231,20 @@ describe('ContactTopics', () => {
     });
 
     it('gets contact topics by ID', async () => {
-      const options: GetContactTopicsOptions = {
+      const options: ListContactTopicsOptions = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
       };
-      const response: GetContactTopicsResponseSuccess = {
+      const response: ListContactTopicsResponseSuccess = {
         has_more: false,
         object: 'list',
-        data: {
-          email: 'carolina@resend.com',
-          topics: [
-            {
-              id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
-              name: 'Test Topic',
-              description: 'This is a test topic',
-              subscription: 'opt_in',
-            },
-          ],
-        },
+        data: [
+          {
+            id: 'c7e1e488-ae2c-4255-a40c-a4db3af7ed0b',
+            name: 'Test Topic',
+            description: 'This is a test topic',
+            subscription: 'opt_in',
+          },
+        ],
       };
 
       mockSuccessResponse(response, {
@@ -262,21 +253,18 @@ describe('ContactTopics', () => {
 
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
       await expect(
-        resend.contacts.topics.get(options),
+        resend.contacts.topics.list(options),
       ).resolves.toMatchInlineSnapshot(`
 {
   "data": {
-    "data": {
-      "email": "carolina@resend.com",
-      "topics": [
-        {
-          "description": "This is a test topic",
-          "id": "c7e1e488-ae2c-4255-a40c-a4db3af7ed0b",
-          "name": "Test Topic",
-          "subscription": "opt_in",
-        },
-      ],
-    },
+    "data": [
+      {
+        "description": "This is a test topic",
+        "id": "c7e1e488-ae2c-4255-a40c-a4db3af7ed0b",
+        "name": "Test Topic",
+        "subscription": "opt_in",
+      },
+    ],
     "has_more": false,
     "object": "list",
   },
@@ -289,8 +277,8 @@ describe('ContactTopics', () => {
       const options = {};
       const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
 
-      const result = resend.contacts.topics.get(
-        options as GetContactTopicsOptions,
+      const result = resend.contacts.topics.list(
+        options as ListContactTopicsOptions,
       );
 
       await expect(result).resolves.toMatchInlineSnapshot(`

--- a/src/contacts/topics/contact-topics.ts
+++ b/src/contacts/topics/contact-topics.ts
@@ -1,10 +1,10 @@
 import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
 import type { Resend } from '../../resend';
 import type {
-  GetContactTopicsOptions,
-  GetContactTopicsResponse,
-  GetContactTopicsResponseSuccess,
-} from './interfaces/get-contact-topics.interface';
+  ListContactTopicsOptions,
+  ListContactTopicsResponse,
+  ListContactTopicsResponseSuccess,
+} from './interfaces/list-contact-topics.interface';
 import type {
   UpdateContactTopicsOptions,
   UpdateContactTopicsResponse,
@@ -37,9 +37,9 @@ export class ContactTopics {
     return data;
   }
 
-  async get(
-    options: GetContactTopicsOptions,
-  ): Promise<GetContactTopicsResponse> {
+  async list(
+    options: ListContactTopicsOptions,
+  ): Promise<ListContactTopicsResponse> {
     if (!options.id && !options.email) {
       return {
         data: null,
@@ -57,7 +57,7 @@ export class ContactTopics {
       ? `/contacts/${identifier}/topics?${queryString}`
       : `/contacts/${identifier}/topics`;
 
-    const data = await this.resend.get<GetContactTopicsResponseSuccess>(url);
+    const data = await this.resend.get<ListContactTopicsResponseSuccess>(url);
     return data;
   }
 }

--- a/src/contacts/topics/interfaces/list-contact-topics.interface.ts
+++ b/src/contacts/topics/interfaces/list-contact-topics.interface.ts
@@ -5,15 +5,15 @@ import type {
 } from '../../../common/interfaces/pagination-options.interface';
 import type { ErrorResponse } from '../../../interfaces';
 
-interface GetContactTopicsBaseOptions {
+interface ListContactTopicsBaseOptions {
   id?: string;
   email?: string;
 }
 
-export type GetContactTopicsOptions = GetContactTopicsBaseOptions &
+export type ListContactTopicsOptions = ListContactTopicsBaseOptions &
   PaginationOptions;
 
-export interface GetContactTopicsRequestOptions extends GetOptions {}
+export interface ListContactTopicsRequestOptions extends GetOptions {}
 
 export interface ContactTopic {
   id: string;
@@ -22,17 +22,11 @@ export interface ContactTopic {
   subscription: 'opt_in' | 'opt_out';
 }
 
-export type GetContactTopicsResponseSuccess = PaginatedData<{
-  email: string;
-  topics: ContactTopic[];
-}>;
+export type ListContactTopicsResponseSuccess = PaginatedData<ContactTopic[]>;
 
-export type GetContactTopicsResponse =
+export type ListContactTopicsResponse =
   | {
-      data: PaginatedData<{
-        email: string;
-        topics: ContactTopic[];
-      }>;
+      data: ListContactTopicsResponseSuccess;
       error: null;
     }
   | {


### PR DESCRIPTION
Fixes the schema of the List Topics endpoint (and updates the method name to match)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Return a normal paginated list of contact topics and rename the client method from get to list. This fixes the incorrect nested response shape and aligns the SDK with API conventions.

- **Migration**
  - Use contacts.topics.list(options) instead of contacts.topics.get(options).
  - Response is now PaginatedData<ContactTopic[]>; remove references to email and topics fields.
  - Update types/imports: GetContactTopics* -> ListContactTopics*.

<!-- End of auto-generated description by cubic. -->

