### PR TITLE
feat: add webhook removal method to SDK

### DIFF
--- a/src/webhooks/interfaces/index.ts
+++ b/src/webhooks/interfaces/index.ts
@@ -14,3 +14,7 @@ export type {
   ListWebhooksResponseSuccess,
   Webhook,
 } from './list-webhooks.interface';
+export type {
+  RemoveWebhookResponse,
+  RemoveWebhookResponseSuccess,
+} from './remove-webhook.interface';

--- a/src/webhooks/interfaces/remove-webhook.interface.ts
+++ b/src/webhooks/interfaces/remove-webhook.interface.ts
@@ -1,0 +1,17 @@
+import type { ErrorResponse } from '../../interfaces';
+import type { Webhook } from './list-webhooks.interface';
+
+export type RemoveWebhookResponseSuccess = Pick<Webhook, 'id'> & {
+  object: 'webhook';
+  deleted: boolean;
+};
+
+export type RemoveWebhookResponse =
+  | {
+      data: RemoveWebhookResponseSuccess;
+      error: null;
+    }
+  | {
+      data: null;
+      error: ErrorResponse;
+    };

--- a/src/webhooks/webhooks.spec.ts
+++ b/src/webhooks/webhooks.spec.ts
@@ -10,6 +10,7 @@ import type {
 } from './interfaces/create-webhook-options.interface';
 import type { GetWebhookResponseSuccess } from './interfaces/get-webhook.interface';
 import type { ListWebhooksResponseSuccess } from './interfaces/list-webhooks.interface';
+import type { RemoveWebhookResponseSuccess } from './interfaces/remove-webhook.interface';
 
 const mocks = vi.hoisted(() => {
   const verify = vi.fn();
@@ -214,6 +215,71 @@ describe('Webhooks', () => {
             headers: expect.any(Headers),
           }),
         );
+      });
+    });
+  });
+
+  describe('remove', () => {
+    it('removes a webhook', async () => {
+      const id = '430eed87-632a-4ea6-90db-0aace67ec228';
+      const response: RemoveWebhookResponseSuccess = {
+        object: 'webhook',
+        id,
+        deleted: true,
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer re_924b3rjh2387fbewf823',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      await expect(resend.webhooks.remove(id)).resolves.toMatchInlineSnapshot(`
+{
+  "data": {
+    "deleted": true,
+    "id": "430eed87-632a-4ea6-90db-0aace67ec228",
+    "object": "webhook",
+  },
+  "error": null,
+}
+`);
+    });
+
+    describe('when webhook not found', () => {
+      it('returns error', async () => {
+        const response: ErrorResponse = {
+          name: 'not_found',
+          message: 'Webhook not found',
+          statusCode: 404,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 404,
+          headers: {
+            'content-type': 'application/json',
+            Authorization: 'Bearer re_924b3rjh2387fbewf823',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.webhooks.remove('1234');
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+{
+  "data": null,
+  "error": {
+    "message": "Webhook not found",
+    "name": "not_found",
+    "statusCode": 404,
+  },
+}
+`);
       });
     });
   });

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -16,6 +16,10 @@ import type {
   ListWebhooksResponse,
   ListWebhooksResponseSuccess,
 } from './interfaces/list-webhooks.interface';
+import type {
+  RemoveWebhookResponse,
+  RemoveWebhookResponseSuccess,
+} from './interfaces/remove-webhook.interface';
 
 interface Headers {
   id: string;
@@ -57,6 +61,13 @@ export class Webhooks {
     const url = queryString ? `/webhooks?${queryString}` : '/webhooks';
 
     const data = await this.resend.get<ListWebhooksResponseSuccess>(url);
+    return data;
+  }
+
+  async remove(id: string): Promise<RemoveWebhookResponse> {
+    const data = await this.resend.delete<RemoveWebhookResponseSuccess>(
+      `/webhooks/${id}`,
+    );
     return data;
   }
 


### PR DESCRIPTION
Add webhook removal method to match with the API implementation. This is important for the inbound flows where webhooks are more prominent.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds webhooks.remove(id) to the SDK to call DELETE /webhooks/:id and return a typed result. This supports PRODUCT-933 (Webhooks delete endpoint) for inbound flows.

- **New Features**
  - Added Webhooks.remove(id): DELETE /webhooks/:id returning { object: 'webhook', id, deleted }.
  - Introduced and exported RemoveWebhookResponse and RemoveWebhookResponseSuccess types.
  - Added tests for success and 404 (returns ErrorResponse).

<!-- End of auto-generated description by cubic. -->

