### PR TITLE
chore: bump to 6.3.0-canary.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.3.0-canary.1",
+  "version": "6.3.0-canary.2",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Let's cut a release with the new CRUD webhook methods!
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumps the package to 6.3.0-canary.2 to cut a canary release that includes the new webhook CRUD methods. No code changes—version only.

<!-- End of auto-generated description by cubic. -->

