### PR TITLE
chore: bump to 6.3.0-canary.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.3.0-canary.2",
+  "version": "6.3.0-canary.3",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Let's cut a release with the GET sending attachments methods!
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prepare canary release 6.3.0-canary.3 to ship the GET sending attachments methods. This updates the package.json version only.

<!-- End of auto-generated description by cubic. -->

