### PR TITLE
chore: bump to 6.4.0-canary.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.3.0-canary.4",
+  "version": "6.4.0-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
We'll be releasing `6.3.0` on latest soon. This bumps canary to the next minor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump canary version to 6.4.0-canary.0 to start the 6.4 development cycle and allow pre-releases while 6.3.0 is promoted to latest.

<!-- End of auto-generated description by cubic. -->

