### PR TITLE
chore: remove duplicated export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,3 @@ export { ErrorResponse } from './interfaces';
 export { Resend } from './resend';
 export * from './segments/interfaces';
 export * from './webhooks/interfaces';
-export * from './webhooks/interfaces';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed a duplicate export of webhooks/interfaces in src/index.ts. This cleans up the public API and avoids redundant re-exports.

<!-- End of auto-generated description by cubic. -->

