### PR TITLE
chore: bump to 6.4.0-canary.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.4.0-canary.0",
+  "version": "6.4.0-canary.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
we need this to make #717 available for beta testers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish canary 6.4.0-canary.1 by bumping package.json, making the changes from #717 available to beta testers.

<!-- End of auto-generated description by cubic. -->

