### PR TITLE
fix: inbound entity should still be called email

### DIFF
--- a/src/emails/receiving/interfaces/get-receiving-email.interface.ts
+++ b/src/emails/receiving/interfaces/get-receiving-email.interface.ts
@@ -1,7 +1,7 @@
 import type { ErrorResponse } from '../../../interfaces';
 
 export interface GetReceivingEmailResponseSuccess {
-  object: 'inbound';
+  object: 'email';
   id: string;
   to: string[];
   from: string;

--- a/src/emails/receiving/receiving.spec.ts
+++ b/src/emails/receiving/receiving.spec.ts
@@ -49,7 +49,7 @@ describe('Receiving', () => {
     describe('when inbound email found', () => {
       it('returns inbound email', async () => {
         const apiResponse: GetReceivingEmailResponseSuccess = {
-          object: 'inbound' as const,
+          object: 'email' as const,
           id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
           to: ['received@example.com'],
           from: 'sender@example.com',
@@ -109,7 +109,7 @@ describe('Receiving', () => {
     },
     "html": "<p>hello world</p>",
     "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
-    "object": "inbound",
+    "object": "email",
     "reply_to": [
       "reply@example.com",
     ],
@@ -126,7 +126,7 @@ describe('Receiving', () => {
 
       it('returns inbound email with no attachments', async () => {
         const apiResponse: GetReceivingEmailResponseSuccess = {
-          object: 'inbound' as const,
+          object: 'email' as const,
           id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
           to: ['received@example.com'],
           from: 'sender@example.com',
@@ -164,7 +164,7 @@ describe('Receiving', () => {
     "headers": {},
     "html": null,
     "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
-    "object": "inbound",
+    "object": "email",
     "reply_to": null,
     "subject": "Test inbound email",
     "text": "hello world",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Changed inbound email response object from 'inbound' to 'email' to match the API contract and avoid confusion.
Updated the interface and tests/fixtures to expect 'email'.

<!-- End of auto-generated description by cubic. -->

