### PR TITLE
fix: revert bump to 6.4.0-canary.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.4.0-canary.1",
+  "version": "6.4.0-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Reverts resend/resend-node#720

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Roll back package version from 6.4.0-canary.1 to 6.4.0-canary.0 to revert the bump and keep canary release numbering consistent.

<!-- End of auto-generated description by cubic. -->

