### PR TITLE
fix: lint to fix import order

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,6 @@ export * from './common/interfaces';
 export * from './contacts/interfaces';
 export * from './domains/interfaces';
 export * from './emails/interfaces';
-export * from './webhooks/interfaces';
 export { ErrorResponse } from './interfaces';
 export { Resend } from './resend';
+export * from './webhooks/interfaces';


### PR DESCRIPTION
This fixes the breaking lint according to import orders that is also breaking main. Once this is merged I'll cherry pick this commit to `main` as well.

Probably happened during fixing the conflicts from rebase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered exports in src/index.ts to satisfy lint rules and fix the failing build. No runtime changes.

<!-- End of auto-generated description by cubic. -->

