### PR TITLE
fix: remove unsupported types

### DIFF
--- a/src/common/interfaces/email-api-options.interface.ts
+++ b/src/common/interfaces/email-api-options.interface.ts
@@ -25,6 +25,6 @@ export interface EmailApiOptions {
   attachments?: EmailApiAttachment[];
   template?: {
     id: string;
-    variables?: Record<string, string | number | boolean>;
+    variables?: Record<string, string | number>;
   };
 }

--- a/src/common/utils/parse-template-to-api-options.spec.ts
+++ b/src/common/utils/parse-template-to-api-options.spec.ts
@@ -38,11 +38,6 @@ describe('parseTemplateToApiOptions', () => {
           fallbackValue: 'Subscriber',
           type: 'string',
         },
-        {
-          key: 'isVip',
-          fallbackValue: false,
-          type: 'boolean',
-        },
       ],
     };
 
@@ -61,11 +56,6 @@ describe('parseTemplateToApiOptions', () => {
           key: 'userName',
           fallback_value: 'Subscriber',
           type: 'string',
-        },
-        {
-          key: 'isVip',
-          fallback_value: false,
-          type: 'boolean',
         },
       ],
     });
@@ -159,11 +149,6 @@ describe('parseTemplateToApiOptions', () => {
           type: 'number',
         },
         {
-          key: 'isEnabled',
-          fallbackValue: true,
-          type: 'boolean',
-        },
-        {
           key: 'optional',
           fallbackValue: null,
           type: 'string',
@@ -183,11 +168,6 @@ describe('parseTemplateToApiOptions', () => {
         key: 'count',
         fallback_value: 42,
         type: 'number',
-      },
-      {
-        key: 'isEnabled',
-        fallback_value: true,
-        type: 'boolean',
       },
       {
         key: 'optional',
@@ -218,132 +198,5 @@ describe('parseTemplateToApiOptions', () => {
     const apiOptions = parseTemplateToApiOptions(templatePayload);
 
     expect(apiOptions.variables).toEqual([]);
-  });
-
-  it('handles object and list variable types for create template', () => {
-    const templatePayload: CreateTemplateOptions = {
-      name: 'Complex Variables Template',
-      html: '<h1>Complex template</h1>',
-      variables: [
-        {
-          key: 'userProfile',
-          type: 'object',
-          fallbackValue: { name: 'John', age: 30 },
-        },
-        {
-          key: 'tags',
-          type: 'list',
-          fallbackValue: ['premium', 'vip'],
-        },
-        {
-          key: 'scores',
-          type: 'list',
-          fallbackValue: [95, 87, 92],
-        },
-        {
-          key: 'flags',
-          type: 'list',
-          fallbackValue: [true, false, true],
-        },
-        {
-          key: 'items',
-          type: 'list',
-          fallbackValue: [{ id: 1 }, { id: 2 }],
-        },
-      ],
-    };
-
-    const apiOptions = parseTemplateToApiOptions(templatePayload);
-
-    expect(apiOptions.variables).toEqual([
-      {
-        key: 'userProfile',
-        type: 'object',
-        fallback_value: { name: 'John', age: 30 },
-      },
-      {
-        key: 'tags',
-        type: 'list',
-        fallback_value: ['premium', 'vip'],
-      },
-      {
-        key: 'scores',
-        type: 'list',
-        fallback_value: [95, 87, 92],
-      },
-      {
-        key: 'flags',
-        type: 'list',
-        fallback_value: [true, false, true],
-      },
-      {
-        key: 'items',
-        type: 'list',
-        fallback_value: [{ id: 1 }, { id: 2 }],
-      },
-    ]);
-  });
-
-  it('handles object and list variable types for update template', () => {
-    const updatePayload: UpdateTemplateOptions = {
-      subject: 'Updated Complex Template',
-      variables: [
-        {
-          key: 'config',
-          type: 'object',
-          fallbackValue: { theme: 'dark', lang: 'en' },
-        },
-        {
-          key: 'permissions',
-          type: 'list',
-          fallbackValue: ['read', 'write'],
-        },
-        {
-          key: 'counts',
-          type: 'list',
-          fallbackValue: [10, 20, 30],
-        },
-        {
-          key: 'enabled',
-          type: 'list',
-          fallbackValue: [true, false],
-        },
-        {
-          key: 'metadata',
-          type: 'list',
-          fallbackValue: [{ key: 'a' }, { key: 'b' }],
-        },
-      ],
-    };
-
-    const apiOptions = parseTemplateToApiOptions(updatePayload);
-
-    expect(apiOptions.variables).toEqual([
-      {
-        key: 'config',
-        type: 'object',
-        fallback_value: { theme: 'dark', lang: 'en' },
-      },
-      {
-        key: 'permissions',
-        type: 'list',
-        fallback_value: ['read', 'write'],
-      },
-      {
-        key: 'counts',
-        type: 'list',
-        fallback_value: [10, 20, 30],
-      },
-      {
-        key: 'enabled',
-        type: 'list',
-        fallback_value: [true, false],
-      },
-      {
-        key: 'metadata',
-        type: 'list',
-        fallback_value: [{ key: 'a' }, { key: 'b' }],
-      },
-    ]);
   });
 });

--- a/src/common/utils/parse-template-to-api-options.ts
+++ b/src/common/utils/parse-template-to-api-options.ts
@@ -1,17 +1,10 @@
 import type { CreateTemplateOptions } from '../../templates/interfaces/create-template-options.interface';
-import type { TemplateVariableListFallbackType } from '../../templates/interfaces/template';
 import type { UpdateTemplateOptions } from '../../templates/interfaces/update-template.interface';
 
 interface TemplateVariableApiOptions {
   key: string;
-  type: 'string' | 'number' | 'boolean' | 'object' | 'list';
-  fallback_value?:
-    | string
-    | number
-    | boolean
-    | Record<string, unknown>
-    | TemplateVariableListFallbackType
-    | null;
+  type: 'string' | 'number';
+  fallback_value?: string | number | null;
 }
 
 interface TemplateApiOptions {

--- a/src/emails/interfaces/create-email-options.interface.ts
+++ b/src/emails/interfaces/create-email-options.interface.ts
@@ -28,7 +28,7 @@ interface EmailRenderOptions {
 interface EmailTemplateOptions {
   template: {
     id: string;
-    variables?: Record<string, string | number | boolean>;
+    variables?: Record<string, string | number>;
   };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restricted template variable types to string and number only, removing boolean, object, and list support. This aligns interfaces and parsing with the email API to prevent invalid payloads.

- **Bug Fixes**
  - Limit variables to Record<string, string | number> in email and template options.
  - Update parseTemplateToApiOptions to handle only string/number fallbacks; removed tests for unsupported types.

- **Migration**
  - Replace boolean/object/list variables with string/number values (e.g., "true"/"false", or JSON string).
  - No changes needed if you already use string/number variables.

<!-- End of auto-generated description by cubic. -->

