### PR TITLE
chore: bump to 6.4.0-canary.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.4.0-canary.0",
+  "version": "6.4.0-canary.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped package.json version from 6.4.0-canary.0 to 6.4.0-canary.1. This tags the next canary release and keeps preview templates on the latest build.

<!-- End of auto-generated description by cubic. -->

