### PR TITLE
feat: remove domain capability from the SDK API

### DIFF
--- a/src/common/interfaces/domain-api-options.interface.ts
+++ b/src/common/interfaces/domain-api-options.interface.ts
@@ -2,5 +2,4 @@ export interface DomainApiOptions {
   name: string;
   region?: string;
   custom_return_path?: string;
-  capability?: 'send' | 'receive' | 'send-and-receive';
 }

--- a/src/common/utils/parse-domain-to-api-options.ts
+++ b/src/common/utils/parse-domain-to-api-options.ts
@@ -7,7 +7,6 @@ export function parseDomainToApiOptions(
   return {
     name: domain.name,
     region: domain.region,
-    capability: domain.capability,
     custom_return_path: domain.customReturnPath,
   };
 }

--- a/src/domains/domains.spec.ts
+++ b/src/domains/domains.spec.ts
@@ -25,7 +25,6 @@ describe('Domains', () => {
       const response: CreateDomainResponseSuccess = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
         name: 'resend.com',
-        capability: 'send-and-receive',
         created_at: '2023-04-07T22:48:33.420498+00:00',
         status: 'not_started',
         records: [
@@ -97,7 +96,6 @@ describe('Domains', () => {
       ).resolves.toMatchInlineSnapshot(`
         {
           "data": {
-            "capability": "send-and-receive",
             "created_at": "2023-04-07T22:48:33.420498+00:00",
             "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222",
             "name": "resend.com",
@@ -207,7 +205,6 @@ describe('Domains', () => {
         const response: CreateDomainResponseSuccess = {
           id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
           name: 'resend.com',
-          capability: 'send',
           created_at: '2023-04-07T22:48:33.420498+00:00',
           status: 'not_started',
           records: [
@@ -267,7 +264,6 @@ describe('Domains', () => {
         ).resolves.toMatchInlineSnapshot(`
           {
             "data": {
-              "capability": "send",
               "created_at": "2023-04-07T22:48:33.420498+00:00",
               "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222",
               "name": "resend.com",
@@ -367,7 +363,6 @@ describe('Domains', () => {
         const response: CreateDomainResponseSuccess = {
           id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
           name: 'resend.com',
-          capability: 'send',
           created_at: '2023-04-07T22:48:33.420498+00:00',
           status: 'not_started',
           records: [
@@ -419,7 +414,6 @@ describe('Domains', () => {
         ).resolves.toMatchInlineSnapshot(`
           {
             "data": {
-              "capability": "send",
               "created_at": "2023-04-07T22:48:33.420498+00:00",
               "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222",
               "name": "resend.com",
@@ -475,7 +469,6 @@ describe('Domains', () => {
           status: 'not_started',
           created_at: '2023-04-07T23:13:52.669661+00:00',
           region: 'eu-west-1',
-          capability: 'send',
         },
         {
           id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
@@ -483,7 +476,6 @@ describe('Domains', () => {
           status: 'not_started',
           created_at: '2023-04-07T23:13:20.417116+00:00',
           region: 'us-east-1',
-          capability: 'receive',
         },
       ],
     };
@@ -649,7 +641,6 @@ describe('Domains', () => {
         object: 'domain',
         id: 'fd61172c-cafc-40f5-b049-b45947779a29',
         name: 'resend.com',
-        capability: 'send-and-receive',
         status: 'not_started',
         created_at: '2023-06-21T06:10:36.144Z',
         region: 'us-east-1',
@@ -705,7 +696,6 @@ describe('Domains', () => {
       await expect(resend.domains.get('1234')).resolves.toMatchInlineSnapshot(`
         {
           "data": {
-            "capability": "send-and-receive",
             "created_at": "2023-06-21T06:10:36.144Z",
             "id": "fd61172c-cafc-40f5-b049-b45947779a29",
             "name": "resend.com",

--- a/src/domains/interfaces/create-domain-options.interface.ts
+++ b/src/domains/interfaces/create-domain-options.interface.ts
@@ -6,16 +6,12 @@ export interface CreateDomainOptions {
   name: string;
   region?: DomainRegion;
   customReturnPath?: string;
-  capability?: 'send' | 'receive' | 'send-and-receive';
 }
 
 export interface CreateDomainRequestOptions extends PostOptions {}
 
 export interface CreateDomainResponseSuccess
-  extends Pick<
-    Domain,
-    'name' | 'id' | 'status' | 'created_at' | 'region' | 'capability'
-  > {
+  extends Pick<Domain, 'name' | 'id' | 'status' | 'created_at' | 'region'> {
   records: DomainRecords[];
 }
 

--- a/src/domains/interfaces/domain.ts
+++ b/src/domains/interfaces/domain.ts
@@ -66,5 +66,4 @@ export interface Domain {
   status: DomainStatus;
   created_at: string;
   region: DomainRegion;
-  capability: 'send' | 'receive' | 'send-and-receive';
 }

--- a/src/domains/interfaces/get-domain.interface.ts
+++ b/src/domains/interfaces/get-domain.interface.ts
@@ -2,10 +2,7 @@ import type { Response } from '../../interfaces';
 import type { Domain, DomainRecords } from './domain';
 
 export interface GetDomainResponseSuccess
-  extends Pick<
-    Domain,
-    'id' | 'name' | 'created_at' | 'region' | 'status' | 'capability'
-  > {
+  extends Pick<Domain, 'id' | 'name' | 'created_at' | 'region' | 'status'> {
   object: 'domain';
   records: DomainRecords[];
 }


### PR DESCRIPTION
We removed the `capability` from being exposed in the API so we can give it some extra thought before we "marry" this API decision.

This removes the prop from the type and updates the tests accordingly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the domain capability field from the SDK API across interfaces, request options, and response types. This aligns with Linear PRODUCT-1013 and temporarily removes capability until the API design is finalized.

- **Migration**
  - Remove capability from create domain calls.
  - Stop reading capability from get/create domain responses.
  - No replacement yet; capability is currently unavailable.

<!-- End of auto-generated description by cubic. -->

