### PR TITLE
feat: add types for getting and setting contact property values

### DIFF
--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -31,7 +31,10 @@ describe('Contacts', () => {
     it('creates a contact', async () => {
       const payload: CreateContactOptions = {
         email: 'team@resend.com',
-        audienceId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
+        properties: {
+          country: 'Canada',
+          edition: 1,
+        },
       };
       const response: CreateContactResponseSuccess = {
         object: 'contact',
@@ -368,6 +371,7 @@ describe('Contacts', () => {
         last_name: '',
         created_at: '2024-01-16T18:12:26.514Z',
         unsubscribed: false,
+        properties: {},
       };
 
       fetchMock.mockOnce(JSON.stringify(response), {
@@ -393,6 +397,7 @@ describe('Contacts', () => {
             "id": "fd61172c-cafc-40f5-b049-b45947779a29",
             "last_name": "",
             "object": "contact",
+            "properties": {},
             "unsubscribed": false,
           },
           "error": null,
@@ -412,6 +417,7 @@ describe('Contacts', () => {
         last_name: '',
         created_at: '2024-01-16T18:12:26.514Z',
         unsubscribed: false,
+        properties: {},
       };
 
       fetchMock.mockOnce(JSON.stringify(response), {
@@ -437,6 +443,7 @@ describe('Contacts', () => {
             "id": "fd61172c-cafc-40f5-b049-b45947779a29",
             "last_name": "",
             "object": "contact",
+            "properties": {},
             "unsubscribed": false,
           },
           "error": null,
@@ -457,6 +464,16 @@ describe('Contacts', () => {
           last_name: '',
           created_at: '2024-01-16T18:12:26.514Z',
           unsubscribed: false,
+          properties: {
+            country: {
+              type: 'string',
+              value: 'Canada',
+            },
+            edition: {
+              type: 'number',
+              value: 1,
+            },
+          },
         };
 
         fetchMock.mockOnce(JSON.stringify(response), {
@@ -481,6 +498,16 @@ describe('Contacts', () => {
               "id": "fd61172c-cafc-40f5-b049-b45947779a29",
               "last_name": "",
               "object": "contact",
+              "properties": {
+                "country": {
+                  "type": "string",
+                  "value": "Canada",
+                },
+                "edition": {
+                  "type": "number",
+                  "value": 1,
+                },
+              },
               "unsubscribed": false,
             },
             "error": null,
@@ -500,6 +527,16 @@ describe('Contacts', () => {
           last_name: '',
           created_at: '2024-01-16T18:12:26.514Z',
           unsubscribed: false,
+          properties: {
+            country: {
+              type: 'string',
+              value: 'Canada',
+            },
+            edition: {
+              type: 'number',
+              value: 1,
+            },
+          },
         };
 
         fetchMock.mockOnce(JSON.stringify(response), {
@@ -524,6 +561,16 @@ describe('Contacts', () => {
               "id": "fd61172c-cafc-40f5-b049-b45947779a29",
               "last_name": "",
               "object": "contact",
+              "properties": {
+                "country": {
+                  "type": "string",
+                  "value": "Canada",
+                },
+                "edition": {
+                  "type": "number",
+                  "value": 1,
+                },
+              },
               "unsubscribed": false,
             },
             "error": null,
@@ -541,6 +588,16 @@ describe('Contacts', () => {
           first_name: '',
           last_name: '',
           created_at: '2024-01-16T18:12:26.514Z',
+          properties: {
+            country: {
+              type: 'string',
+              value: 'Canada',
+            },
+            edition: {
+              type: 'number',
+              value: 1,
+            },
+          },
           unsubscribed: false,
         };
 
@@ -563,6 +620,16 @@ describe('Contacts', () => {
               "id": "fd61172c-cafc-40f5-b049-b45947779a29",
               "last_name": "",
               "object": "contact",
+              "properties": {
+                "country": {
+                  "type": "string",
+                  "value": "Canada",
+                },
+                "edition": {
+                  "type": "number",
+                  "value": 1,
+                },
+              },
               "unsubscribed": false,
             },
             "error": null,
@@ -589,6 +656,16 @@ describe('Contacts', () => {
           first_name: '',
           last_name: '',
           created_at: '2024-01-16T18:12:26.514Z',
+          properties: {
+            country: {
+              type: 'string',
+              value: 'Canada',
+            },
+            edition: {
+              type: 'number',
+              value: 1,
+            },
+          },
           unsubscribed: false,
         };
 
@@ -611,6 +688,16 @@ describe('Contacts', () => {
               "id": "fd61172c-cafc-40f5-b049-b45947779a29",
               "last_name": "",
               "object": "contact",
+              "properties": {
+                "country": {
+                  "type": "string",
+                  "value": "Canada",
+                },
+                "edition": {
+                  "type": "number",
+                  "value": 1,
+                },
+              },
               "unsubscribed": false,
             },
             "error": null,
@@ -635,8 +722,11 @@ describe('Contacts', () => {
     it('updates a contact', async () => {
       const payload: UpdateContactOptions = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
-        audienceId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
         firstName: 'Bu',
+        properties: {
+          country: 'Canada',
+          edition: 1,
+        },
       };
       const response = {
         id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -51,6 +51,7 @@ export class Contacts {
           email: payload.email,
           first_name: payload.firstName,
           last_name: payload.lastName,
+          properties: payload.properties,
         },
         options,
       );
@@ -137,6 +138,7 @@ export class Contacts {
           unsubscribed: options.unsubscribed,
           first_name: options.firstName,
           last_name: options.lastName,
+          properties: options.properties,
         },
       );
       return data;

--- a/src/contacts/interfaces/create-contact-options.interface.ts
+++ b/src/contacts/interfaces/create-contact-options.interface.ts
@@ -2,12 +2,17 @@ import type { PostOptions } from '../../common/interfaces';
 import type { Response } from '../../interfaces';
 import type { Contact } from './contact';
 
+interface CreateContactPropertiesOptions {
+  [key: string]: string | number | null;
+}
+
 export interface CreateContactOptions {
   audienceId?: string;
   email: string;
   unsubscribed?: boolean;
   firstName?: string;
   lastName?: string;
+  properties?: CreateContactPropertiesOptions;
 }
 
 export interface CreateContactRequestOptions extends PostOptions {}

--- a/src/contacts/interfaces/get-contact.interface.ts
+++ b/src/contacts/interfaces/get-contact.interface.ts
@@ -7,12 +7,27 @@ export type GetContactOptions =
       audienceId?: string;
     } & SelectingField);
 
+type ContactPropertyValue =
+  | {
+      type: 'string';
+      value: string;
+    }
+  | {
+      type: 'number';
+      value: number;
+    };
+
+interface ContactProperties {
+  [key: string]: ContactPropertyValue;
+}
+
 export interface GetContactResponseSuccess
   extends Pick<
     Contact,
     'id' | 'email' | 'created_at' | 'first_name' | 'last_name' | 'unsubscribed'
   > {
   object: 'contact';
+  properties: ContactProperties;
 }
 
 export type GetContactResponse = Response<GetContactResponseSuccess>;

--- a/src/contacts/interfaces/update-contact.interface.ts
+++ b/src/contacts/interfaces/update-contact.interface.ts
@@ -1,11 +1,16 @@
 import type { Response } from '../../interfaces';
 import type { Contact, SelectingField } from './contact';
 
+interface UpdateContactPropertiesOptions {
+  [key: string]: string | number | null;
+}
+
 export type UpdateContactOptions = {
   audienceId?: string;
   unsubscribed?: boolean;
   firstName?: string;
   lastName?: string;
+  properties?: UpdateContactPropertiesOptions;
 } & SelectingField;
 
 export type UpdateContactResponseSuccess = Pick<Contact, 'id'> & {


### PR DESCRIPTION
This PR adds the return type of GET /contacts to include custom properties, as well as the input types for POST and PATCH /contacts to accept property values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed support for contact custom properties. GET now includes typed property values, and POST/PATCH accept property inputs.

- **New Features**
  - GET /contacts returns properties as a map of { type, value } (supports string and number).
  - CreateContactOptions and UpdateContactOptions accept properties: { [key]: string | number | null }.
  - SDK forwards properties in create and update requests; tests updated to cover property handling.

<!-- End of auto-generated description by cubic. -->

