### PR TITLE
fix: allow PR titles to start with numbers

### DIFF
--- a/.github/scripts/pr-title-check.js
+++ b/.github/scripts/pr-title-check.js
@@ -5,7 +5,7 @@ const eventJson = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
 const prTitle = eventJson.pull_request.title;
 
 const isValidType = (title) =>
-  /^(feat|fix|chore|refactor)(\([a-zA-Z0-9-]+\))?:\s[a-z].*$/.test(title);
+  /^(feat|fix|chore|refactor)(\([a-zA-Z0-9-]+\))?:\s[a-z0-9].*$/.test(title);
 
 const validateTitle = (title) => {
   if (!isValidType(title)) {


### PR DESCRIPTION
fix: allow PR titles to start with numbers

The PR title check regex required the first character after the type
to be lowercase a-z, which rejected valid titles like "fix: 404 page...".

Updated regex to accept [a-z0-9] instead of just [a-z].

This fixes the issue seen in:
https://github.com/resend/resend/actions/runs/19054315360/job/54421298890?pr=7034

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow PR titles to start with numbers by updating the regex in .github/scripts/pr-title-check.js, so valid titles like "fix: 404 page..." pass validation. This prevents CI failures caused by the previous rule requiring a lowercase letter after the type.

<sup>Written for commit 1f2a1b93cb1abab9fefb8859aa2aef19f4ba85a9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

