### PR TITLE
fix: include properties on payload of both contacts APIs

### DIFF
--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -65,6 +65,7 @@ export class Contacts {
         email: payload.email,
         first_name: payload.firstName,
         last_name: payload.lastName,
+        properties: payload.properties,
       },
       options,
     );
@@ -150,6 +151,7 @@ export class Contacts {
         unsubscribed: options.unsubscribed,
         first_name: options.firstName,
         last_name: options.lastName,
+        properties: options.properties,
       },
     );
     return data;


### PR DESCRIPTION
They were missing from `create` and `update` contacts when using the previous contacts API

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include properties in the payload for create and update in the previous contacts API. Ensures custom properties are sent and persisted when creating or updating contacts.

<sup>Written for commit c3ac915d54d6f60ed7db99edcd6fa7edd7797beb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

