### PR TITLE
chore: bump version to 6.4.1-canary.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.4.0",
+  "version": "6.4.1-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare canary pre-release 6.4.1-canary.0 for the Resend Node.js SDK. Updates package.json version for publishing; no code changes.

<sup>Written for commit 3a13089e726f6f62b964be0f8af978bca92786a3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

