### PR TITLE
chore: bump version to 6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.4.1-canary.0",
+  "version": "6.4.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Promoted package.json version from 6.4.1-canary.0 to 6.4.1 to publish the stable release. No code changes.

<sup>Written for commit 9a22baceb084f2099a0e5844014a0e5a336bf418. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

