### PR TITLE
fix: accept segmentId for listing contacts

### DIFF
--- a/src/contacts/__recordings__/Contacts-Integration-Tests-list-lists-contacts-with-limit_871347592/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-list-lists-contacts-with-limit_871347592/recording.har
@@ -25,10 +25,10 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 181,
+          "headersSize": 172,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -40,11 +40,11 @@
           "url": "https://api.resend.com/segments"
         },
         "response": {
-          "bodySize": 111,
+          "bodySize": 110,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 111,
-            "text": "{\"object\":\"audience\",\"id\":\"59e81eca-46ce-44d8-a8c7-6eb2c2350f30\",\"name\":\"Test audience for listing with limit\"}"
+            "size": 110,
+            "text": "{\"object\":\"segment\",\"id\":\"fee5f31e-7721-4915-8439-3a8317c0d528\",\"name\":\"Test audience for listing with limit\"}"
           },
           "cookies": [],
           "headers": [
@@ -54,7 +54,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "990174958f8cad76-PDX"
+              "value": "99ad46cf1e6a8884-DUB"
             },
             {
               "name": "connection",
@@ -62,7 +62,7 @@
             },
             {
               "name": "content-length",
-              "value": "111"
+              "value": "110"
             },
             {
               "name": "content-type",
@@ -70,11 +70,11 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:28 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:24 GMT"
             },
             {
               "name": "etag",
-              "value": "W/\"6f-nj0fLhvMB7bgJqryScghpVt/OA0\""
+              "value": "W/\"6e-I4+FHoFt8KXefQu5RhHmvcU9oPc\""
             },
             {
               "name": "ratelimit-limit",
@@ -86,7 +86,7 @@
             },
             {
               "name": "ratelimit-remaining",
-              "value": "19"
+              "value": "17"
             },
             {
               "name": "ratelimit-reset",
@@ -103,8 +103,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:28.714Z",
-        "time": 161,
+        "startedDateTime": "2025-11-07T13:46:24.400Z",
+        "time": 146,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -112,11 +112,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 161
+          "wait": 146
         }
       },
       {
-        "_id": "e281e196584e342749f9137ef5f52b5e",
+        "_id": "5b332b9d170253927d0643d4acbdf083",
         "_order": 0,
         "cache": {},
         "request": {
@@ -133,10 +133,10 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 228,
+          "headersSize": 219,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -145,7 +145,7 @@
             "text": "{\"email\":\"test.0@example.com\"}"
           },
           "queryString": [],
-          "url": "https://api.resend.com/audiences/59e81eca-46ce-44d8-a8c7-6eb2c2350f30/contacts"
+          "url": "https://api.resend.com/audiences/fee5f31e-7721-4915-8439-3a8317c0d528/contacts"
         },
         "response": {
           "bodySize": 64,
@@ -162,7 +162,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "99017496996b5913-PDX"
+              "value": "99ad46cffa0e90af-DUB"
             },
             {
               "name": "connection",
@@ -178,227 +178,11 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:29 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:24 GMT"
             },
             {
               "name": "etag",
               "value": "W/\"40-SPEIaxqwNgrPerxsVehA4Mc2YSw\""
-            },
-            {
-              "name": "ratelimit-limit",
-              "value": "20"
-            },
-            {
-              "name": "ratelimit-policy",
-              "value": "20;w=1"
-            },
-            {
-              "name": "ratelimit-remaining",
-              "value": "18"
-            },
-            {
-              "name": "ratelimit-reset",
-              "value": "1"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 201,
-          "statusText": "Created"
-        },
-        "startedDateTime": "2025-10-17T17:18:28.877Z",
-        "time": 262,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 262
-        }
-      },
-      {
-        "_id": "a2aa4d213b82b2d932f85021e08ff0a5",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 30,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "authorization",
-              "value": "Bearer re_REDACTED_API_KEY"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
-            }
-          ],
-          "headersSize": 228,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"email\":\"test.1@example.com\"}"
-          },
-          "queryString": [],
-          "url": "https://api.resend.com/audiences/59e81eca-46ce-44d8-a8c7-6eb2c2350f30/contacts"
-        },
-        "response": {
-          "bodySize": 64,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 64,
-            "text": "{\"object\":\"contact\",\"id\":\"d2301d07-ed3a-4a67-bd3c-e68a2f402906\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "cf-ray",
-              "value": "990174983870ad76-PDX"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "content-length",
-              "value": "64"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:29 GMT"
-            },
-            {
-              "name": "etag",
-              "value": "W/\"40-ypz1BtR9vGrNgplMnqFHflskWSQ\""
-            },
-            {
-              "name": "ratelimit-limit",
-              "value": "20"
-            },
-            {
-              "name": "ratelimit-policy",
-              "value": "20;w=1"
-            },
-            {
-              "name": "ratelimit-remaining",
-              "value": "17"
-            },
-            {
-              "name": "ratelimit-reset",
-              "value": "1"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 201,
-          "statusText": "Created"
-        },
-        "startedDateTime": "2025-10-17T17:18:29.140Z",
-        "time": 341,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 341
-        }
-      },
-      {
-        "_id": "d09a9532fa24a0ddb1f6fcf975c1440a",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 30,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "authorization",
-              "value": "Bearer re_REDACTED_API_KEY"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
-            }
-          ],
-          "headersSize": 228,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"email\":\"test.2@example.com\"}"
-          },
-          "queryString": [],
-          "url": "https://api.resend.com/audiences/59e81eca-46ce-44d8-a8c7-6eb2c2350f30/contacts"
-        },
-        "response": {
-          "bodySize": 64,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 64,
-            "text": "{\"object\":\"contact\",\"id\":\"b2636f63-45f7-4fae-9636-3b9ed474099d\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "cf-ray",
-              "value": "9901749a5cd15913-PDX"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "content-length",
-              "value": "64"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:29 GMT"
-            },
-            {
-              "name": "etag",
-              "value": "W/\"40-eTTX5ZC9b/wIluwj/KM0k+9Rkik\""
             },
             {
               "name": "ratelimit-limit",
@@ -427,8 +211,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:29.482Z",
-        "time": 255,
+        "startedDateTime": "2025-11-07T13:46:24.547Z",
+        "time": 359,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -436,11 +220,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 255
+          "wait": 359
         }
       },
       {
-        "_id": "c2af0bd01bf47ea30352582ab9509c38",
+        "_id": "4478f55cb851135a3299b4120fd4d36a",
         "_order": 0,
         "cache": {},
         "request": {
@@ -457,26 +241,26 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 228,
+          "headersSize": 219,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"email\":\"test.3@example.com\"}"
+            "text": "{\"email\":\"test.1@example.com\"}"
           },
           "queryString": [],
-          "url": "https://api.resend.com/audiences/59e81eca-46ce-44d8-a8c7-6eb2c2350f30/contacts"
+          "url": "https://api.resend.com/audiences/fee5f31e-7721-4915-8439-3a8317c0d528/contacts"
         },
         "response": {
           "bodySize": 64,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 64,
-            "text": "{\"object\":\"contact\",\"id\":\"8a57452b-164e-4e35-b7cf-41087d9dce9b\"}"
+            "text": "{\"object\":\"contact\",\"id\":\"d2301d07-ed3a-4a67-bd3c-e68a2f402906\"}"
           },
           "cookies": [],
           "headers": [
@@ -486,7 +270,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "9901749bfdd4ad76-PDX"
+              "value": "99ad46d24b848884-DUB"
             },
             {
               "name": "connection",
@@ -502,11 +286,119 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:30 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:25 GMT"
             },
             {
               "name": "etag",
-              "value": "W/\"40-nkeZzqF7RB7Sf8tLV2fEgsmcWeg\""
+              "value": "W/\"40-ypz1BtR9vGrNgplMnqFHflskWSQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "20"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "20;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "15"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-07T13:46:24.906Z",
+        "time": 359,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 359
+        }
+      },
+      {
+        "_id": "87d19c5178b9400a4fd959fef020dad1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.4.1"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.2@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/fee5f31e-7721-4915-8439-3a8317c0d528/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"b2636f63-45f7-4fae-9636-3b9ed474099d\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "99ad46d4890290af-DUB"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 Nov 2025 13:46:25 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-eTTX5ZC9b/wIluwj/KM0k+9Rkik\""
             },
             {
               "name": "ratelimit-limit",
@@ -535,8 +427,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:29.738Z",
-        "time": 308,
+        "startedDateTime": "2025-11-07T13:46:25.267Z",
+        "time": 376,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -544,11 +436,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 308
+          "wait": 376
         }
       },
       {
-        "_id": "5b18d5a0c5bdf29b7efa4fa48fb08929",
+        "_id": "719740404b452161d1472911cb2b8f99",
         "_order": 0,
         "cache": {},
         "request": {
@@ -565,26 +457,26 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 228,
+          "headersSize": 219,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"email\":\"test.4@example.com\"}"
+            "text": "{\"email\":\"test.3@example.com\"}"
           },
           "queryString": [],
-          "url": "https://api.resend.com/audiences/59e81eca-46ce-44d8-a8c7-6eb2c2350f30/contacts"
+          "url": "https://api.resend.com/audiences/fee5f31e-7721-4915-8439-3a8317c0d528/contacts"
         },
         "response": {
           "bodySize": 64,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 64,
-            "text": "{\"object\":\"contact\",\"id\":\"38ddf490-a2de-4ddd-ac89-361dd5fc2e35\"}"
+            "text": "{\"object\":\"contact\",\"id\":\"8a57452b-164e-4e35-b7cf-41087d9dce9b\"}"
           },
           "cookies": [],
           "headers": [
@@ -594,7 +486,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "9901749dd8135913-PDX"
+              "value": "99ad46d6da858884-DUB"
             },
             {
               "name": "connection",
@@ -610,11 +502,11 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:30 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:26 GMT"
             },
             {
               "name": "etag",
-              "value": "W/\"40-Ik+FFo//vczDSIdDQENIJWjKCUs\""
+              "value": "W/\"40-nkeZzqF7RB7Sf8tLV2fEgsmcWeg\""
             },
             {
               "name": "ratelimit-limit",
@@ -643,8 +535,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:30.047Z",
-        "time": 355,
+        "startedDateTime": "2025-11-07T13:46:25.644Z",
+        "time": 408,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -652,11 +544,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 355
+          "wait": 408
         }
       },
       {
-        "_id": "40e23df8de4e228681e77d206050f037",
+        "_id": "e1f6690a2480dec8037d978f026f38cd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -673,26 +565,26 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 228,
+          "headersSize": 219,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"email\":\"test.5@example.com\"}"
+            "text": "{\"email\":\"test.4@example.com\"}"
           },
           "queryString": [],
-          "url": "https://api.resend.com/audiences/59e81eca-46ce-44d8-a8c7-6eb2c2350f30/contacts"
+          "url": "https://api.resend.com/audiences/fee5f31e-7721-4915-8439-3a8317c0d528/contacts"
         },
         "response": {
           "bodySize": 64,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 64,
-            "text": "{\"object\":\"contact\",\"id\":\"ef6b0bba-5e87-4360-8f12-493ee2d31adb\"}"
+            "text": "{\"object\":\"contact\",\"id\":\"38ddf490-a2de-4ddd-ac89-361dd5fc2e35\"}"
           },
           "cookies": [],
           "headers": [
@@ -702,7 +594,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "990174a01d4aad76-PDX"
+              "value": "99ad46d9692c90af-DUB"
             },
             {
               "name": "connection",
@@ -718,11 +610,11 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:30 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:26 GMT"
             },
             {
               "name": "etag",
-              "value": "W/\"40-W7N8ixsRtC8IRQU5RNbQ7dUAPrY\""
+              "value": "W/\"40-Ik+FFo//vczDSIdDQENIJWjKCUs\""
             },
             {
               "name": "ratelimit-limit",
@@ -751,8 +643,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:30.403Z",
-        "time": 254,
+        "startedDateTime": "2025-11-07T13:46:26.053Z",
+        "time": 510,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -760,11 +652,119 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 254
+          "wait": 510
         }
       },
       {
-        "_id": "6050a57b5c2fd774de74c96650746680",
+        "_id": "3447e0ff8a90cecbaaddb056fb33f9a7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.4.1"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.5@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/fee5f31e-7721-4915-8439-3a8317c0d528/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"ef6b0bba-5e87-4360-8f12-493ee2d31adb\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "99ad46dc9b768884-DUB"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 Nov 2025 13:46:26 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-W7N8ixsRtC8IRQU5RNbQ7dUAPrY\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "20"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "20;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "19"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-07T13:46:26.564Z",
+        "time": 330,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 330
+        }
+      },
+      {
+        "_id": "dd708ff25d3a35a64ade3641b7a8d54f",
         "_order": 0,
         "cache": {},
         "request": {
@@ -781,10 +781,10 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 235,
+          "headersSize": 225,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -793,7 +793,7 @@
               "value": "5"
             }
           ],
-          "url": "https://api.resend.com/audiences/59e81eca-46ce-44d8-a8c7-6eb2c2350f30/contacts?limit=5"
+          "url": "https://api.resend.com/segments/fee5f31e-7721-4915-8439-3a8317c0d528/contacts?limit=5"
         },
         "response": {
           "bodySize": 921,
@@ -810,7 +810,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "990174a1bc125913-PDX"
+              "value": "99ad46deb9f290af-DUB"
             },
             {
               "name": "connection",
@@ -826,7 +826,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:30 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:27 GMT"
             },
             {
               "name": "etag",
@@ -842,7 +842,7 @@
             },
             {
               "name": "ratelimit-remaining",
-              "value": "16"
+              "value": "18"
             },
             {
               "name": "ratelimit-reset",
@@ -863,8 +863,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2025-10-17T17:18:30.659Z",
-        "time": 154,
+        "startedDateTime": "2025-11-07T13:46:26.898Z",
+        "time": 136,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -872,11 +872,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 154
+          "wait": 136
         }
       },
       {
-        "_id": "3b1c2334541543ace3170de6a4d80b80",
+        "_id": "23f65788453a2100c2ba18211fafdaf1",
         "_order": 0,
         "cache": {},
         "request": {
@@ -893,21 +893,21 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 220,
+          "headersSize": 211,
           "httpVersion": "HTTP/1.1",
           "method": "DELETE",
           "queryString": [],
-          "url": "https://api.resend.com/segments/59e81eca-46ce-44d8-a8c7-6eb2c2350f30"
+          "url": "https://api.resend.com/segments/fee5f31e-7721-4915-8439-3a8317c0d528"
         },
         "response": {
-          "bodySize": 80,
+          "bodySize": 79,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 80,
-            "text": "{\"object\":\"audience\",\"id\":\"59e81eca-46ce-44d8-a8c7-6eb2c2350f30\",\"deleted\":true}"
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"fee5f31e-7721-4915-8439-3a8317c0d528\",\"deleted\":true}"
           },
           "cookies": [],
           "headers": [
@@ -917,7 +917,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "990174a2aec3ad76-PDX"
+              "value": "99ad46df8fd98884-DUB"
             },
             {
               "name": "connection",
@@ -933,11 +933,11 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:31 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:27 GMT"
             },
             {
               "name": "etag",
-              "value": "W/\"50-M9ULFfz+EKzIEGEXBm8C8Sd92r4\""
+              "value": "W/\"4f-ELAlUQXnLLWFJ6I1kSZW0KPxBwM\""
             },
             {
               "name": "ratelimit-limit",
@@ -949,7 +949,7 @@
             },
             {
               "name": "ratelimit-remaining",
-              "value": "19"
+              "value": "17"
             },
             {
               "name": "ratelimit-reset",
@@ -970,8 +970,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2025-10-17T17:18:30.815Z",
-        "time": 289,
+        "startedDateTime": "2025-11-07T13:46:27.034Z",
+        "time": 246,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -979,7 +979,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 289
+          "wait": 246
         }
       }
     ],

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-list-lists-contacts-without-pagination_2611532587/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-list-lists-contacts-without-pagination_2611532587/recording.har
@@ -25,10 +25,10 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 181,
+          "headersSize": 172,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -40,11 +40,11 @@
           "url": "https://api.resend.com/segments"
         },
         "response": {
-          "bodySize": 100,
+          "bodySize": 99,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 100,
-            "text": "{\"object\":\"audience\",\"id\":\"92112b37-2b3c-4aeb-83fb-2f473fa4d740\",\"name\":\"Test audience for listing\"}"
+            "size": 99,
+            "text": "{\"object\":\"segment\",\"id\":\"f64d0a81-d33f-43da-a402-6634f4d1ae1f\",\"name\":\"Test audience for listing\"}"
           },
           "cookies": [],
           "headers": [
@@ -54,7 +54,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "990174878f355913-PDX"
+              "value": "99ad46bcfdfa90af-DUB"
             },
             {
               "name": "connection",
@@ -62,7 +62,7 @@
             },
             {
               "name": "content-length",
-              "value": "100"
+              "value": "99"
             },
             {
               "name": "content-type",
@@ -70,119 +70,11 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:26 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:21 GMT"
             },
             {
               "name": "etag",
-              "value": "W/\"64-USObuVXxaszt+hyix9qHsXQUB0A\""
-            },
-            {
-              "name": "ratelimit-limit",
-              "value": "20"
-            },
-            {
-              "name": "ratelimit-policy",
-              "value": "20;w=1"
-            },
-            {
-              "name": "ratelimit-remaining",
-              "value": "19"
-            },
-            {
-              "name": "ratelimit-reset",
-              "value": "1"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            }
-          ],
-          "headersSize": 341,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 201,
-          "statusText": "Created"
-        },
-        "startedDateTime": "2025-10-17T17:18:26.474Z",
-        "time": 159,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 159
-        }
-      },
-      {
-        "_id": "018799e15322462f5bc40d79b52822be",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 30,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "authorization",
-              "value": "Bearer re_REDACTED_API_KEY"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
-            }
-          ],
-          "headersSize": 228,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"email\":\"test.0@example.com\"}"
-          },
-          "queryString": [],
-          "url": "https://api.resend.com/audiences/92112b37-2b3c-4aeb-83fb-2f473fa4d740/contacts"
-        },
-        "response": {
-          "bodySize": 64,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 64,
-            "text": "{\"object\":\"contact\",\"id\":\"2ce5866a-84d9-4933-8d28-7ef402bb17d1\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "cf-ray",
-              "value": "990174888b07ad76-PDX"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "content-length",
-              "value": "64"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:26 GMT"
-            },
-            {
-              "name": "etag",
-              "value": "W/\"40-SPEIaxqwNgrPerxsVehA4Mc2YSw\""
+              "value": "W/\"63-VRUJSYJjJYqOfTOAOGo5yOzMnzU\""
             },
             {
               "name": "ratelimit-limit",
@@ -211,8 +103,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:26.634Z",
-        "time": 268,
+        "startedDateTime": "2025-11-07T13:46:21.497Z",
+        "time": 147,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -220,11 +112,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 268
+          "wait": 147
         }
       },
       {
-        "_id": "160f1ba1f4266bf163c26002e15f195e",
+        "_id": "7d39447c560fe097a7405fab3084f9cc",
         "_order": 0,
         "cache": {},
         "request": {
@@ -241,26 +133,26 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 228,
+          "headersSize": 219,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"email\":\"test.1@example.com\"}"
+            "text": "{\"email\":\"test.0@example.com\"}"
           },
           "queryString": [],
-          "url": "https://api.resend.com/audiences/92112b37-2b3c-4aeb-83fb-2f473fa4d740/contacts"
+          "url": "https://api.resend.com/audiences/f64d0a81-d33f-43da-a402-6634f4d1ae1f/contacts"
         },
         "response": {
           "bodySize": 64,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 64,
-            "text": "{\"object\":\"contact\",\"id\":\"d2301d07-ed3a-4a67-bd3c-e68a2f402906\"}"
+            "text": "{\"object\":\"contact\",\"id\":\"2ce5866a-84d9-4933-8d28-7ef402bb17d1\"}"
           },
           "cookies": [],
           "headers": [
@@ -270,7 +162,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "9901748a3fad5913-PDX"
+              "value": "99ad46bdda9a8884-DUB"
             },
             {
               "name": "connection",
@@ -286,11 +178,11 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:27 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:22 GMT"
             },
             {
               "name": "etag",
-              "value": "W/\"40-ypz1BtR9vGrNgplMnqFHflskWSQ\""
+              "value": "W/\"40-SPEIaxqwNgrPerxsVehA4Mc2YSw\""
             },
             {
               "name": "ratelimit-limit",
@@ -319,8 +211,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:26.903Z",
-        "time": 327,
+        "startedDateTime": "2025-11-07T13:46:21.645Z",
+        "time": 359,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -328,11 +220,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 327
+          "wait": 359
         }
       },
       {
-        "_id": "4614c250ed122a7ee4958dea76ad97c6",
+        "_id": "28447e131235030f0e15640510f8bf07",
         "_order": 0,
         "cache": {},
         "request": {
@@ -349,26 +241,26 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 228,
+          "headersSize": 219,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"email\":\"test.2@example.com\"}"
+            "text": "{\"email\":\"test.1@example.com\"}"
           },
           "queryString": [],
-          "url": "https://api.resend.com/audiences/92112b37-2b3c-4aeb-83fb-2f473fa4d740/contacts"
+          "url": "https://api.resend.com/audiences/f64d0a81-d33f-43da-a402-6634f4d1ae1f/contacts"
         },
         "response": {
           "bodySize": 64,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 64,
-            "text": "{\"object\":\"contact\",\"id\":\"b2636f63-45f7-4fae-9636-3b9ed474099d\"}"
+            "text": "{\"object\":\"contact\",\"id\":\"d2301d07-ed3a-4a67-bd3c-e68a2f402906\"}"
           },
           "cookies": [],
           "headers": [
@@ -378,7 +270,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "9901748c4f60ad76-PDX"
+              "value": "99ad46c01add90af-DUB"
             },
             {
               "name": "connection",
@@ -394,11 +286,11 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:27 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:22 GMT"
             },
             {
               "name": "etag",
-              "value": "W/\"40-eTTX5ZC9b/wIluwj/KM0k+9Rkik\""
+              "value": "W/\"40-ypz1BtR9vGrNgplMnqFHflskWSQ\""
             },
             {
               "name": "ratelimit-limit",
@@ -427,8 +319,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:27.231Z",
-        "time": 281,
+        "startedDateTime": "2025-11-07T13:46:22.006Z",
+        "time": 331,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -436,11 +328,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 281
+          "wait": 331
         }
       },
       {
-        "_id": "19c54bab554140a0c55d2e2b71fafef5",
+        "_id": "9da88921c7d0a61418a9f29a8e5a8516",
         "_order": 0,
         "cache": {},
         "request": {
@@ -457,10 +349,118 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 228,
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.2@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/f64d0a81-d33f-43da-a402-6634f4d1ae1f/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"b2636f63-45f7-4fae-9636-3b9ed474099d\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "99ad46c238f48884-DUB"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 07 Nov 2025 13:46:22 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-eTTX5ZC9b/wIluwj/KM0k+9Rkik\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "20"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "20;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "15"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-07T13:46:22.338Z",
+        "time": 437,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 437
+        }
+      },
+      {
+        "_id": "d0ae1b5608313e9f119660cc38868e3d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.4.1"
+            }
+          ],
+          "headersSize": 219,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -469,7 +469,7 @@
             "text": "{\"email\":\"test.3@example.com\"}"
           },
           "queryString": [],
-          "url": "https://api.resend.com/audiences/92112b37-2b3c-4aeb-83fb-2f473fa4d740/contacts"
+          "url": "https://api.resend.com/audiences/f64d0a81-d33f-43da-a402-6634f4d1ae1f/contacts"
         },
         "response": {
           "bodySize": 64,
@@ -486,7 +486,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "9901748e0da85913-PDX"
+              "value": "99ad46c4e9f690af-DUB"
             },
             {
               "name": "connection",
@@ -502,7 +502,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:27 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:23 GMT"
             },
             {
               "name": "etag",
@@ -535,8 +535,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:27.512Z",
-        "time": 248,
+        "startedDateTime": "2025-11-07T13:46:22.777Z",
+        "time": 411,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -544,11 +544,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 248
+          "wait": 411
         }
       },
       {
-        "_id": "9c330a59f1800cd2cb5d8a13f3bb4439",
+        "_id": "1adcc36d6cb74b07e750ef666017468a",
         "_order": 0,
         "cache": {},
         "request": {
@@ -565,10 +565,10 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 228,
+          "headersSize": 219,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -577,7 +577,7 @@
             "text": "{\"email\":\"test.4@example.com\"}"
           },
           "queryString": [],
-          "url": "https://api.resend.com/audiences/92112b37-2b3c-4aeb-83fb-2f473fa4d740/contacts"
+          "url": "https://api.resend.com/audiences/f64d0a81-d33f-43da-a402-6634f4d1ae1f/contacts"
         },
         "response": {
           "bodySize": 64,
@@ -594,7 +594,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "9901748f9ae2ad76-PDX"
+              "value": "99ad46c789dd8884-DUB"
             },
             {
               "name": "connection",
@@ -610,7 +610,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:27 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:23 GMT"
             },
             {
               "name": "etag",
@@ -643,8 +643,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:27.761Z",
-        "time": 238,
+        "startedDateTime": "2025-11-07T13:46:23.190Z",
+        "time": 407,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -652,11 +652,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 238
+          "wait": 407
         }
       },
       {
-        "_id": "8c845d58009faa21e611093dd041f9f6",
+        "_id": "9881d0eaf67ee456d5c9cced3b161597",
         "_order": 0,
         "cache": {},
         "request": {
@@ -673,10 +673,10 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 228,
+          "headersSize": 219,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -685,7 +685,7 @@
             "text": "{\"email\":\"test.5@example.com\"}"
           },
           "queryString": [],
-          "url": "https://api.resend.com/audiences/92112b37-2b3c-4aeb-83fb-2f473fa4d740/contacts"
+          "url": "https://api.resend.com/audiences/f64d0a81-d33f-43da-a402-6634f4d1ae1f/contacts"
         },
         "response": {
           "bodySize": 64,
@@ -702,7 +702,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "990174911fc95913-PDX"
+              "value": "99ad46ca195190af-DUB"
             },
             {
               "name": "connection",
@@ -718,7 +718,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:28 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:24 GMT"
             },
             {
               "name": "etag",
@@ -751,8 +751,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2025-10-17T17:18:28.001Z",
-        "time": 255,
+        "startedDateTime": "2025-11-07T13:46:23.599Z",
+        "time": 404,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -760,11 +760,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 255
+          "wait": 404
         }
       },
       {
-        "_id": "2fbe917448561c27fcf7f4886a6c9b6a",
+        "_id": "f4e9151d7fb46ad9f96ee28b53648419",
         "_order": 0,
         "cache": {},
         "request": {
@@ -781,14 +781,14 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 227,
+          "headersSize": 217,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.resend.com/audiences/92112b37-2b3c-4aeb-83fb-2f473fa4d740/contacts"
+          "url": "https://api.resend.com/segments/f64d0a81-d33f-43da-a402-6634f4d1ae1f/contacts"
         },
         "response": {
           "bodySize": 1098,
@@ -805,7 +805,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "99017492bdbdad76-PDX"
+              "value": "99ad46cc9a768884-DUB"
             },
             {
               "name": "connection",
@@ -821,7 +821,7 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:28 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:24 GMT"
             },
             {
               "name": "etag",
@@ -837,7 +837,7 @@
             },
             {
               "name": "ratelimit-remaining",
-              "value": "16"
+              "value": "19"
             },
             {
               "name": "ratelimit-reset",
@@ -858,8 +858,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2025-10-17T17:18:28.258Z",
-        "time": 201,
+        "startedDateTime": "2025-11-07T13:46:24.004Z",
+        "time": 152,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -867,11 +867,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 201
+          "wait": 152
         }
       },
       {
-        "_id": "5d335154a64b7a44a8c72229eb45da1e",
+        "_id": "51f9e699af0506cb7ef04fbc0cd18eda",
         "_order": 0,
         "cache": {},
         "request": {
@@ -888,21 +888,21 @@
             },
             {
               "name": "user-agent",
-              "value": "resend-node:6.3.0-canary.0"
+              "value": "resend-node:6.4.1"
             }
           ],
-          "headersSize": 220,
+          "headersSize": 211,
           "httpVersion": "HTTP/1.1",
           "method": "DELETE",
           "queryString": [],
-          "url": "https://api.resend.com/segments/92112b37-2b3c-4aeb-83fb-2f473fa4d740"
+          "url": "https://api.resend.com/segments/f64d0a81-d33f-43da-a402-6634f4d1ae1f"
         },
         "response": {
-          "bodySize": 80,
+          "bodySize": 79,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 80,
-            "text": "{\"object\":\"audience\",\"id\":\"92112b37-2b3c-4aeb-83fb-2f473fa4d740\",\"deleted\":true}"
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"f64d0a81-d33f-43da-a402-6634f4d1ae1f\",\"deleted\":true}"
           },
           "cookies": [],
           "headers": [
@@ -912,7 +912,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "99017493fa45ad76-PDX"
+              "value": "99ad46cd8bed8884-DUB"
             },
             {
               "name": "connection",
@@ -928,11 +928,11 @@
             },
             {
               "name": "date",
-              "value": "Fri, 17 Oct 2025 17:18:28 GMT"
+              "value": "Fri, 07 Nov 2025 13:46:24 GMT"
             },
             {
               "name": "etag",
-              "value": "W/\"50-/gYbLxfuFX9Iy0Byw/iyMwl/ySI\""
+              "value": "W/\"4f-bPdr14rYhSd0LO9p78E2Qh7nHFU\""
             },
             {
               "name": "ratelimit-limit",
@@ -944,7 +944,7 @@
             },
             {
               "name": "ratelimit-remaining",
-              "value": "15"
+              "value": "18"
             },
             {
               "name": "ratelimit-reset",
@@ -965,8 +965,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2025-10-17T17:18:28.460Z",
-        "time": 248,
+        "startedDateTime": "2025-11-07T13:46:24.157Z",
+        "time": 239,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -974,7 +974,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 248
+          "wait": 239
         }
       }
     ],

--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -105,7 +105,7 @@ describe('Contacts', () => {
     describe('without pagination', () => {
       it('lists contacts', async () => {
         const options: ListContactsOptions = {
-          audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
+          segmentId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
         };
         const response: ListContactsResponseSuccess = {
           object: 'list',
@@ -146,14 +146,14 @@ describe('Contacts', () => {
         });
 
         expect(fetchMock).toHaveBeenCalledWith(
-          'https://api.resend.com/audiences/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts',
+          'https://api.resend.com/segments/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts',
           expect.objectContaining({
             method: 'GET',
             headers: expect.any(Headers),
           }),
         );
       });
-      describe('when audienceId is not provided', () => {
+      describe('when segmentId is not provided', () => {
         it('lists contacts', async () => {
           const options: ListContactsOptions = {
             limit: 10,
@@ -246,7 +246,7 @@ describe('Contacts', () => {
 
         const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
         const result = await resend.contacts.list({
-          audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
+          segmentId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
           limit: 1,
         });
         expect(result).toEqual({
@@ -258,7 +258,7 @@ describe('Contacts', () => {
         });
 
         expect(fetchMock).toHaveBeenCalledWith(
-          'https://api.resend.com/audiences/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts?limit=1',
+          'https://api.resend.com/segments/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts?limit=1',
           expect.objectContaining({
             method: 'GET',
             headers: expect.any(Headers),
@@ -273,7 +273,7 @@ describe('Contacts', () => {
 
         const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
         const result = await resend.contacts.list({
-          audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
+          segmentId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
           limit: 1,
           after: 'cursor-value',
         });
@@ -286,7 +286,7 @@ describe('Contacts', () => {
         });
 
         expect(fetchMock).toHaveBeenCalledWith(
-          'https://api.resend.com/audiences/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts?limit=1&after=cursor-value',
+          'https://api.resend.com/segments/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts?limit=1&after=cursor-value',
           expect.objectContaining({
             method: 'GET',
             headers: expect.any(Headers),
@@ -301,7 +301,7 @@ describe('Contacts', () => {
 
         const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
         const result = await resend.contacts.list({
-          audienceId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
+          segmentId: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381a',
           limit: 1,
           before: 'cursor-value',
         });
@@ -314,7 +314,7 @@ describe('Contacts', () => {
         });
 
         expect(fetchMock).toHaveBeenCalledWith(
-          'https://api.resend.com/audiences/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts?limit=1&before=cursor-value',
+          'https://api.resend.com/segments/b6d24b8e-af0b-4c3c-be0c-359bbd97381a/contacts?limit=1&before=cursor-value',
           expect.objectContaining({
             method: 'GET',
             headers: expect.any(Headers),

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -12,7 +12,6 @@ import type {
   GetContactResponseSuccess,
 } from './interfaces/get-contact.interface';
 import type {
-  ListAudienceContactsOptions,
   ListContactsOptions,
   ListContactsResponse,
   ListContactsResponseSuccess,
@@ -72,21 +71,19 @@ export class Contacts {
     return data;
   }
 
-  async list(
-    options: ListContactsOptions | ListAudienceContactsOptions = {},
-  ): Promise<ListContactsResponse> {
-    if (!('audienceId' in options) || options.audienceId === undefined) {
+  async list(options: ListContactsOptions = {}): Promise<ListContactsResponse> {
+    const segmentId = options.segmentId ?? options.audienceId;
+    if (!segmentId) {
       const queryString = buildPaginationQuery(options);
       const url = queryString ? `/contacts?${queryString}` : '/contacts';
       const data = await this.resend.get<ListContactsResponseSuccess>(url);
       return data;
     }
 
-    const { audienceId, ...paginationOptions } = options;
-    const queryString = buildPaginationQuery(paginationOptions);
+    const queryString = buildPaginationQuery(options);
     const url = queryString
-      ? `/audiences/${audienceId}/contacts?${queryString}`
-      : `/audiences/${audienceId}/contacts`;
+      ? `/segments/${segmentId}/contacts?${queryString}`
+      : `/segments/${segmentId}/contacts`;
     const data = await this.resend.get<ListContactsResponseSuccess>(url);
     return data;
   }

--- a/src/contacts/interfaces/list-contacts.interface.ts
+++ b/src/contacts/interfaces/list-contacts.interface.ts
@@ -3,11 +3,11 @@ import type { PaginationOptions } from '../../common/interfaces';
 import type { Response } from '../../interfaces';
 import type { Contact } from './contact';
 
-export type ListAudienceContactsOptions = {
-  audienceId: string;
-} & PaginationOptions;
-
 export type ListContactsOptions = PaginationOptions & {
+  segmentId?: string;
+  /**
+   * @deprecated Use segmentId instead to filter by segment
+   */
   audienceId?: string;
 };
 


### PR DESCRIPTION
This PR allows filtering contacts by a `segmentId` when listing them. `audienceId` is still supported for backwards compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for segmentId when listing contacts and switches requests to /segments/:id/contacts. audienceId is still accepted for backward compatibility, but is now deprecated.

- **New Features**
  - Added segmentId to contacts.list to filter by segment.
  - Kept audienceId support by mapping it to segmentId (marked deprecated).
  - Uses /segments/:id/contacts for filtered lists; unfiltered listing and pagination still work.

- **Migration**
  - Replace audienceId with segmentId in contacts.list calls.

<sup>Written for commit 38ce8733558285ae9087539fc9acea6c251a50d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

