### PR TITLE
fix: type ErrorResponse exported as non-type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export * from './domains/interfaces';
 export * from './emails/attachments/interfaces';
 export * from './emails/interfaces';
 export * from './emails/receiving/interfaces';
-export { ErrorResponse } from './interfaces';
+export type { ErrorResponse, Response } from './interfaces';
 export { Resend } from './resend';
 export * from './segments/interfaces';
 export * from './webhooks/interfaces';


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the barrel export to use type-only exports for ErrorResponse and Response. This fixes the previous non-type export and prevents runtime/ESM issues by keeping these as compile-time types only.

<sup>Written for commit c1f143a7e665bd989995e11d07d78369fd15267f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

