### PR TITLE
feat(ci): run pnpm build during Tests/tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
       - name: Install packages
         run: pnpm install
+      - name: Run build
+        run: pnpm build
       - name: Run Tests
         run: pnpm test
         env:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a pnpm build step to the CI Tests workflow so we catch build errors before running tests and ensure tests run against compiled output. This builds right after install and before pnpm test.

<sup>Written for commit 8845ff97af1a77ff7dd079c4fb99147054dbd89f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

