### PR TITLE
fix: devEngines syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "node": ">=20"
   },
   "devEngines": {
-    "node": ">=22"
+    "runtime": {
+      "name": "node",
+      "version": ">=22.0.0"
+    }
   },
   "exports": {
     ".": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix the devEngines schema in package.json to use the runtime object so tooling correctly detects Node >=22.0.0 for development.
Prevents CI and local scripts from misreading the dev engine requirement.

<sup>Written for commit b5870a8740d4241003b4690ad498d9c74b82b65f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

