### PR TITLE
fix: main and types in package.json (bumping as a patch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Closes #751

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected package.json entry points to fix module and type resolution for CommonJS and TypeScript users. Set main to ./dist/index.cjs and types to ./dist/index.d.mts, and bumped the package to 6.5.1.

<sup>Written for commit f684d7b487e2dd46af309f9098944ba3294144b3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

