### PR TITLE
feat: add open_tracking, click_tracking, and tls fields to domain create

### DIFF
--- a/src/common/interfaces/domain-api-options.interface.ts
+++ b/src/common/interfaces/domain-api-options.interface.ts
@@ -5,4 +5,7 @@ export interface DomainApiOptions {
   region?: string;
   custom_return_path?: string;
   capabilities?: Partial<DomainCapabilities>;
+  open_tracking?: boolean;
+  click_tracking?: boolean;
+  tls?: 'enforced' | 'opportunistic';
 }

--- a/src/common/utils/parse-domain-to-api-options.ts
+++ b/src/common/utils/parse-domain-to-api-options.ts
@@ -9,5 +9,8 @@ export function parseDomainToApiOptions(
     region: domain.region,
     custom_return_path: domain.customReturnPath,
     capabilities: domain.capabilities,
+    open_tracking: domain.openTracking,
+    click_tracking: domain.clickTracking,
+    tls: domain.tls,
   };
 }

--- a/src/domains/interfaces/create-domain-options.interface.ts
+++ b/src/domains/interfaces/create-domain-options.interface.ts
@@ -12,6 +12,9 @@ export interface CreateDomainOptions {
   region?: DomainRegion;
   customReturnPath?: string;
   capabilities?: Partial<DomainCapabilities>;
+  openTracking?: boolean;
+  clickTracking?: boolean;
+  tls?: 'enforced' | 'opportunistic';
 }
 
 export interface CreateDomainRequestOptions extends PostOptions {}


### PR DESCRIPTION
Add support for configuring tracking and TLS options during domain creation.

Related: resend/resend-api#2179