### PR TITLE
feat: allow experimental batch endpoint

### DIFF
--- a/src/batch/batch.spec.ts
+++ b/src/batch/batch.spec.ts
@@ -650,4 +650,73 @@ describe('Batch', () => {
       ]);
     });
   });
+
+  describe('experimental batch endpoint', () => {
+    const originalEnv = process.env.RESEND_EXPERIMENTAL_BATCH;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.RESEND_EXPERIMENTAL_BATCH;
+      } else {
+        process.env.RESEND_EXPERIMENTAL_BATCH = originalEnv;
+      }
+    });
+
+    it('uses experimental endpoint by default', async () => {
+      delete process.env.RESEND_EXPERIMENTAL_BATCH;
+
+      mockSuccessResponse(
+        {
+          data: [{ id: 'experimental-email-1' }],
+        },
+        {
+          headers: {},
+        },
+      );
+
+      const payload: CreateBatchOptions = [
+        {
+          from: 'admin@resend.com',
+          to: 'user@resend.com',
+          subject: 'Test',
+          html: '<h1>Test</h1>',
+        },
+      ];
+
+      await resend.batch.create(payload);
+
+      const lastCall = fetchMock.mock.calls[0];
+      const url = lastCall[0] as string;
+      expect(url).toContain('/experimental/emails/batch');
+    });
+
+    it('uses standard endpoint when RESEND_EXPERIMENTAL_BATCH is "false"', async () => {
+      process.env.RESEND_EXPERIMENTAL_BATCH = 'false';
+
+      mockSuccessResponse(
+        {
+          data: [{ id: 'standard-email-1' }],
+        },
+        {
+          headers: {},
+        },
+      );
+
+      const payload: CreateBatchOptions = [
+        {
+          from: 'admin@resend.com',
+          to: 'user@resend.com',
+          subject: 'Test',
+          html: '<h1>Test</h1>',
+        },
+      ];
+
+      await resend.batch.create(payload);
+
+      const lastCall = fetchMock.mock.calls[0];
+      const url = lastCall[0] as string;
+      expect(url).toContain('/emails/batch');
+      expect(url).not.toContain('/experimental/emails/batch');
+    });
+  });
 });

--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -34,8 +34,17 @@ export class Batch {
       emails.push(parseEmailToApiOptions(email));
     }
 
+    const useExperimental =
+      typeof process !== 'undefined' && process.env
+        ? process.env.RESEND_EXPERIMENTAL_BATCH !== 'false' &&
+          process.env.RESEND_EXPERIMENTAL_BATCH !== '0'
+        : true;
+    const endpoint = useExperimental
+      ? '/experimental/emails/batch'
+      : '/emails/batch';
+
     const data = await this.resend.post<CreateBatchSuccessResponse<Options>>(
-      '/emails/batch',
+      endpoint,
       emails,
       {
         ...options,


### PR DESCRIPTION
> ⚠️ I'm merging this into `batch-preview` instead of `canary` to avoid people accidentally releasing this version. I'll release the preview tag from there.

This PR will be released as a separate version tag `v6.5.x-batch.0`. It's aimed at giving customers early access to the new batch endpoint so we can test with real samples whether our improvements led to good results.

Note that this "depends" on other PRs in our API and also some settings on our load balancers.

Also note that I made this be "on" by default so that customers have to do as little configuration as possible to get started. Still, they can turn it off by setting the environment variable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the experimental batch email endpoint by default to let customers try it with real traffic.

- **New Features**
  - Routes batch requests to /experimental/emails/batch by default.
  - Set RESEND_EXPERIMENTAL_BATCH to "false" or "0" to use /emails/batch.

<sup>Written for commit 77d35888bf30929842c51522669ba23fb94e20e1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

