### PR TITLE
fix: missing error code names

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,9 +23,9 @@ export type RESEND_ERROR_CODE_KEY =
 
 export type Response<T> = (
   | {
-    data: T;
-    error: null;
-  }
+      data: T;
+      error: null;
+    }
   | { error: ErrorResponse; data: null }
 ) & {
   headers: Record<string, string> | null;


### PR DESCRIPTION
Adds missing error code names as described in issue: #765

Reorders code names to match documentation.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing RESEND error codes, removed an outdated one, and reordered the union to match the API docs. Aligns client types with server responses to prevent undefined code handling.

- **Bug Fixes**
  - Added: restricted_api_key, invalid_attachment, monthly_quota_exceeded, daily_quota_exceeded, security_error
  - Reordered existing codes to mirror API documentation

<sup>Written for commit 8d9105975aad02c87a1b24258425040e033fb7f9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



