### PR TITLE
feat: add raw url to types returned from inbound individual GET API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.6.0",
+  "version": "6.6.0-preview-raw-inbound.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/emails/receiving/interfaces/get-receiving-email.interface.ts
+++ b/src/emails/receiving/interfaces/get-receiving-email.interface.ts
@@ -14,6 +14,10 @@ export interface GetReceivingEmailResponseSuccess {
   text: string | null;
   headers: Record<string, string>;
   message_id: string;
+  raw: {
+    download_url: string;
+    expires_at: string;
+  } | null;
   attachments: Array<{
     id: string;
     filename: string;

--- a/src/emails/receiving/interfaces/list-receiving-emails.interface.ts
+++ b/src/emails/receiving/interfaces/list-receiving-emails.interface.ts
@@ -6,7 +6,7 @@ export type ListReceivingEmailsOptions = PaginationOptions;
 
 export type ListReceivingEmail = Omit<
   GetReceivingEmailResponseSuccess,
-  'html' | 'text' | 'headers' | 'object'
+  'html' | 'text' | 'headers' | 'raw' | 'object'
 >;
 
 export interface ListReceivingEmailsResponseSuccess {

--- a/src/emails/receiving/receiving.spec.ts
+++ b/src/emails/receiving/receiving.spec.ts
@@ -70,7 +70,7 @@ describe('Receiving', () => {
           raw: {
             download_url:
               'https://example.com/emails/raw/abc123?signature=xyz789',
-            expires_at: '2023-04-07T24:13:52.669661+00:00',
+            expires_at: '2023-04-08T00:13:52.669661+00:00',
           },
           attachments: [
             {
@@ -124,7 +124,7 @@ describe('Receiving', () => {
               "object": "email",
               "raw": {
                 "download_url": "https://example.com/emails/raw/abc123?signature=xyz789",
-                "expires_at": "2023-04-07T24:13:52.669661+00:00",
+                "expires_at": "2023-04-08T00:13:52.669661+00:00",
               },
               "reply_to": [
                 "reply@example.com",

--- a/src/emails/receiving/receiving.spec.ts
+++ b/src/emails/receiving/receiving.spec.ts
@@ -67,6 +67,11 @@ describe('Receiving', () => {
           headers: {
             example: 'value',
           },
+          raw: {
+            download_url:
+              'https://example.com/emails/raw/abc123?signature=xyz789',
+            expires_at: '2023-04-07T24:13:52.669661+00:00',
+          },
           attachments: [
             {
               id: 'att_123',
@@ -117,6 +122,10 @@ describe('Receiving', () => {
               "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
               "message_id": "msg_123",
               "object": "email",
+              "raw": {
+                "download_url": "https://example.com/emails/raw/abc123?signature=xyz789",
+                "expires_at": "2023-04-07T24:13:52.669661+00:00",
+              },
               "reply_to": [
                 "reply@example.com",
               ],
@@ -148,6 +157,7 @@ describe('Receiving', () => {
           cc: null,
           reply_to: null,
           headers: {},
+          raw: null,
           attachments: [],
           message_id: 'msg_456',
         };
@@ -176,6 +186,7 @@ describe('Receiving', () => {
               "id": "67d9bcdb-5a02-42d7-8da9-0d6feea18cff",
               "message_id": "msg_456",
               "object": "email",
+              "raw": null,
               "reply_to": null,
               "subject": "Test inbound email",
               "text": "hello world",


### PR DESCRIPTION
This PR adds the new types necessary for the feature-flagged option to download raw emails.

We don't need any change in functionality as these will work mostly like the download URLs for attachments, at least for now.

Please do not merge until the FF is enabled for all users.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds raw email download metadata to the inbound individual GET API types to enable raw email downloads behind a feature flag. Updates list types and tests; no runtime behavior change.

- **New Features**
  - Added raw: { download_url: string; expires_at: string } | null to GetReceivingEmailResponseSuccess.
  - Omitted raw from ListReceivingEmail to keep list payloads small.
  - Extended tests to cover raw present and null cases.

<sup>Written for commit 56d6fe44560c57257b2a076c1fe89262779db069. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



