### PR TITLE
chore: release raw inbound preview version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.6.0",
+  "version": "6.7.0-preview-raw-inbound.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
This is just for me to release a preview version with the raw inbound types before we release #774. That way, we don't have to commit to this particular API response before we get feedback.

This will be short-lived, just probably one or two weeks until users confirm this is what they needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release a preview build with raw inbound types so users can try the API and provide feedback before finalizing #774. Version updated to 6.7.0-preview-raw-inbound.0; this preview is temporary.

<sup>Written for commit 22416992594814ad80d79d3014c58088eaea05dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

