### PR TITLE
feat: release `6.7.0-canary.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.6.0",
+  "version": "6.7.0-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publish canary pre-release 6.7.0-canary.0 of the Resend Node library to enable testing ahead of 6.7.0. Updates package.json version only; no code changes.

<sup>Written for commit cb6387b6d450e2acc1bed7508f39772cdc1e2cd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

