### PR TITLE
feat: release `6.7.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.7.0-canary.0",
+  "version": "6.7.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Promoted the library from canary to stable by updating the package.json version to 6.7.0. No functional changes; this publishes the 6.7.0 release.

<sup>Written for commit c519742cd2fe5d6bf0694cb3b2f2f8fb4550d950. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

