### PR TITLE
feat: create and send broadcasts on the same request

### DIFF
--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -83,6 +83,73 @@ describe('Broadcasts', () => {
       `);
     });
 
+    it('creates and sends a broadcast', async () => {
+      const response: CreateBroadcastResponseSuccess = {
+        id: '71cdfe68-cf79-473a-a9d7-21f91db6a526',
+      };
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const payload: CreateBroadcastOptions = {
+        from: 'bu@resend.com',
+        segmentId: '0192f4ed-c2e9-7112-9c13-b04a043e23ee',
+        subject: 'Hello World',
+        html: '<h1>Hello world</h1>',
+        send: true,
+      };
+
+      const data = await resend.broadcasts.create(payload);
+      expect(data).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "71cdfe68-cf79-473a-a9d7-21f91db6a526",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+    });
+
+    it('creates and schedules a broadcast', async () => {
+      const response: CreateBroadcastResponseSuccess = {
+        id: '71cdfe68-cf79-473a-a9d7-21f91db6a526',
+      };
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const payload: CreateBroadcastOptions = {
+        from: 'bu@resend.com',
+        segmentId: '0192f4ed-c2e9-7112-9c13-b04a043e23ee',
+        subject: 'Hello World',
+        html: '<h1>Hello world</h1>',
+        send: true,
+        scheduledAt: '2024-08-05T11:52:01.858Z',
+      };
+
+      const data = await resend.broadcasts.create(payload);
+      expect(data).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "71cdfe68-cf79-473a-a9d7-21f91db6a526",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+    });
+
     it('creates broadcast with multiple recipients', async () => {
       const response: CreateBroadcastResponseSuccess = {
         id: '124dc0f1-e36c-417c-a65c-e33773abc768',

--- a/src/broadcasts/broadcasts.ts
+++ b/src/broadcasts/broadcasts.ts
@@ -53,6 +53,8 @@ export class Broadcasts {
         subject: payload.subject,
         text: payload.text,
         topic_id: payload.topicId,
+        send: payload.send,
+        scheduled_at: payload.scheduledAt,
       },
       options,
     );

--- a/src/broadcasts/interfaces/create-broadcast-options.interface.ts
+++ b/src/broadcasts/interfaces/create-broadcast-options.interface.ts
@@ -37,6 +37,42 @@ interface SegmentOptions {
   audienceId: string;
 }
 
+type SendBroadcastOnCreationOptions =
+  | {
+      /**
+       * Whether to send the broadcast immediately or keep it as a draft.
+       * If not provided or set to false, the broadcast will be created as a draft.
+       *
+       * @link https://resend.com/docs/api-reference/broadcasts/create#body-parameters
+       */
+      send: true;
+      /**
+       * Schedule time to send the broadcast. Can only be used if `send` is true.
+       * The date should be in ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z)
+       * or relative time (eg: in 2 days).
+       *
+       * @link https://resend.com/docs/api-reference/broadcasts/create#body-parameters
+       */
+      scheduledAt?: string;
+    }
+  | {
+      /**
+       * Whether to send the broadcast immediately or keep it as a draft.
+       * If not provided or set to false, the broadcast will be created as a draft.
+       *
+       * @link https://resend.com/docs/api-reference/broadcasts/create#body-parameters
+       */
+      send?: false;
+      /**
+       * Schedule time to send the broadcast. Can only be used if `send` is true.
+       * The date should be in ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z)
+       * or relative time (eg: in 2 days).
+       *
+       * @link https://resend.com/docs/api-reference/broadcasts/create#body-parameters
+       */
+      scheduledAt?: never;
+    };
+
 interface CreateBroadcastBaseOptions {
   /**
    * The name of the broadcast
@@ -78,7 +114,8 @@ interface CreateBroadcastBaseOptions {
 
 export type CreateBroadcastOptions = RequireAtLeastOne<EmailRenderOptions> &
   RequireAtLeastOne<SegmentOptions> &
-  CreateBroadcastBaseOptions;
+  CreateBroadcastBaseOptions &
+  SendBroadcastOnCreationOptions;
 
 export interface CreateBroadcastRequestOptions extends PostOptions {}
 


### PR DESCRIPTION
This PR introduces the ability to send or schedule a Broadcast within the same request that creates it. Before, you needed to first create a Broadcast and issue a second request to `POST /broadcasts/:id/send` to send or schedule it.

A Broadcast is sent on creation when passing `send: true` as part of the creation payload. All options available on `POST /broadcasts/:id/send` are also available when using `send: true` during creation (namely, `scheduledAt` for scheduling the broadcast). Using any of these options with `send: false | undefined` is an error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create and send (or schedule) a Broadcast in a single request. This removes the extra POST /broadcasts/:id/send step while keeping the same send options.

- **New Features**
  - POST /broadcasts now accepts send: true to send on create; use scheduledAt to schedule.
  - Type-safe create payload: scheduledAt is only allowed when send is true; otherwise it errors.
  - Added tests for immediate send and scheduled send.

<sup>Written for commit a8280e14c02267f067de59df092e7661ef526fd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

