### PR TITLE
feat(contacts): create contact with segments and topics

### DIFF
--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-create-creates-a-contact_379717911/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-create-creates-a-contact_379717911/recording.har
@@ -1,0 +1,767 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > create > creates a contact",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "11ce2844c53df106f278d53fdf23e936",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 46,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for contact creation 1\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 109,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 109,
+            "text": "{\"object\":\"segment\",\"id\":\"abd0e207-0192-48e6-b2b4-4214b8b2aaad\",\"name\":\"Test segment for contact creation 1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4083995deea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "109"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:33 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"6d-XYsLMxITT86EP9Y8ORhfRQ5BwPg\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:31.866Z",
+        "time": 833,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 833
+        }
+      },
+      {
+        "_id": "49eb0128fb4965181f570de9aa847bf1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 77,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 170,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test topic for contact creation 1\",\"default_subscription\":\"opt_out\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/topics"
+        },
+        "response": {
+          "bodySize": 62,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 62,
+            "text": "{\"object\":\"topic\",\"id\":\"c7a931cb-4507-46de-a3c1-e1b7efd274c2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40878ab4edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "62"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:33 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"3e-VdxagcSwgK8oVp+9EFOLcSH8lw8\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:32.701Z",
+        "time": 365,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 365
+        }
+      },
+      {
+        "_id": "b6f274e9a3b0e5785a514bc74a263dde",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 83,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 182,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"key\":\"test_property_for_contacts_api\",\"type\":\"string\",\"fallback_value\":\"unknown\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contact-properties"
+        },
+        "response": {
+          "bodySize": 73,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 73,
+            "text": "{\"object\":\"contact_property\",\"id\":\"69850362-f2c9-429c-b7a1-4bcc834bdbf8\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40894879eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "73"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:33 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"49-N4Iw2lPNSemobEKnpOktEKdEXU0\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:33.070Z",
+        "time": 173,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 173
+        }
+      },
+      {
+        "_id": "815cf6edb498a12469aa2a7c7767de9c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 271,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test@example.com\",\"first_name\":\"Test\",\"last_name\":\"User\",\"properties\":{\"test_property_for_contacts_api\":\"updated value\"},\"segments\":[{\"id\":\"abd0e207-0192-48e6-b2b4-4214b8b2aaad\"}],\"topics\":[{\"id\":\"c7a931cb-4507-46de-a3c1-e1b7efd274c2\",\"subscription\":\"opt_in\"}]}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"bacce9f0-7193-41b9-baf1-ad060e1be3f4\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d408a5af3edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:34 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-6WWYp42MZkMf/Scy3lJPR3GRAH0\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:33.247Z",
+        "time": 564,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 564
+        }
+      },
+      {
+        "_id": "66accc34da863461c0059c5b251a57d9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/abd0e207-0192-48e6-b2b4-4214b8b2aaad"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"abd0e207-0192-48e6-b2b4-4214b8b2aaad\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d408dfc90eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:34 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-DcB3hAuA2a4baeW9pfZq2EpV4hc\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:33.814Z",
+        "time": 261,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 261
+        }
+      },
+      {
+        "_id": "3bb8cd75c5973afc06eb24049401f1e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 209,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/topics/c7a931cb-4507-46de-a3c1-e1b7efd274c2"
+        },
+        "response": {
+          "bodySize": 77,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 77,
+            "text": "{\"object\":\"topic\",\"id\":\"c7a931cb-4507-46de-a3c1-e1b7efd274c2\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d408f8857eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:34 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4d-4db8mMGnth+XgWUQNoYb1zTwZR0\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:34.076Z",
+        "time": 331,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 331
+        }
+      },
+      {
+        "_id": "4888be24c11ab4328590167e9dd85e44",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 221,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/contact-properties/69850362-f2c9-429c-b7a1-4bcc834bdbf8"
+        },
+        "response": {
+          "bodySize": 88,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 88,
+            "text": "{\"object\":\"contact_property\",\"deleted\":true,\"id\":\"69850362-f2c9-429c-b7a1-4bcc834bdbf8\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4091add9eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:34 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"58-JsxhEak1cgr3gkqweVIbkszRAXw\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:34.408Z",
+        "time": 182,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 182
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-create-handles-validation-errors_4021415180/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-create-handles-validation-errors_4021415180/recording.har
@@ -1,0 +1,122 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > create > handles validation errors",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "7e36d93bf833d78073dab4d08fb175ea",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 85,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 85,
+            "text": "{\"statusCode\":422,\"message\":\"Missing `email` field.\",\"name\":\"missing_required_field\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4092d8f3eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "85"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:35 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"55-3twEi8WnC2GKqaYdAl7cGsmeByc\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 422,
+          "statusText": "Unprocessable Entity"
+        },
+        "startedDateTime": "2025-11-30T20:56:34.601Z",
+        "time": 170,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 170
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-get-retrieves-a-contact-by-email_2206692250/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-get-retrieves-a-contact-by-email_2206692250/recording.har
@@ -1,0 +1,229 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > get > retrieves a contact by email",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "91928cc4617639a2034b4278df307427",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 41,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test-get-by-email@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"7c8272c4-ed16-4d01-8202-17fb3b1a04ea\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40b80965eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:41 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-heiKa1R1sYWT2rhn3Pu5CpmYVTc\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:40.562Z",
+        "time": 288,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 288
+        }
+      },
+      {
+        "_id": "70c5e9377d072322ddac67f0c0bd118a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 201,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts/test-get-by-email@example.com"
+        },
+        "response": {
+          "bodySize": 221,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 221,
+            "text": "{\"object\":\"contact\",\"id\":\"7c8272c4-ed16-4d01-8202-17fb3b1a04ea\",\"email\":\"test-get-by-email@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:59.540771+00\",\"unsubscribed\":false,\"properties\":{}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40b9dfe5edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:41 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"dd-qIzaKtcamGT6J9ousJWHXCIKORI\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:40.851Z",
+        "time": 192,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 192
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-get-retrieves-a-contact-by-id_1300391795/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-get-retrieves-a-contact-by-id_1300391795/recording.har
@@ -1,0 +1,229 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > get > retrieves a contact by id",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "0a247d519432f31fbc23c59d76f10fe1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 38,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test-get-by-id@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"e242c221-be74-4ff4-b8dc-0efb234dd6a1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40b519d6eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:40 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-Db1lRTfeXvUi9lYlVNxnF6X7jJ4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:40.083Z",
+        "time": 284,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 284
+        }
+      },
+      {
+        "_id": "9ed15810f4e79f1f9c196706f2f2ed8d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 208,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts/e242c221-be74-4ff4-b8dc-0efb234dd6a1"
+        },
+        "response": {
+          "bodySize": 218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 218,
+            "text": "{\"object\":\"contact\",\"id\":\"e242c221-be74-4ff4-b8dc-0efb234dd6a1\",\"email\":\"test-get-by-id@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:41:44.782119+00\",\"unsubscribed\":false,\"properties\":{}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40b6d809edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:40 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"da-irFfqWd48pWyj0zzbPbauK/FSe4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:40.368Z",
+        "time": 190,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 190
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-get-returns-error-for-non-existent-conta_2430661441/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-get-returns-error-for-non-existent-conta_2430661441/recording.har
@@ -1,0 +1,121 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > get > returns error for non-existent contact",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "fd7a886fc92a31d06716d84f16285db5",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 208,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts/00000000-0000-0000-0000-000000000000"
+        },
+        "response": {
+          "bodySize": 67,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 67,
+            "text": "{\"statusCode\":404,\"message\":\"Contact not found\",\"name\":\"not_found\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40bb0985eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:41 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"43-Hlm9sCxABe1C/S9NDIZg0PaqfAM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "95"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2025-11-30T20:56:41.048Z",
+        "time": 241,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 241
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-list-lists-contacts-with-limit_3763649692/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-list-lists-contacts-with-limit_3763649692/recording.har
@@ -1,0 +1,1416 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > list > lists contacts with limit",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "83e58161ced06c05af0cc1f63153593f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.0@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"32cd6208-6e08-40b9-bdfe-0b5d6d6ce37b\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d42541c3120ec-AMS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:47 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-oCf0ZoThdabXPeMRR8OgTcY0+0s\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:46.483Z",
+        "time": 316,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 316
+        }
+      },
+      {
+        "_id": "2dbb7c24904530ede9712e7bcd591940",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.1@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"92e3a543-ba27-4c62-bc22-68247e51b244\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4256088759ad-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:47 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-1haCgo5fg1x9u+1S5MnhWRDWvdQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:46.800Z",
+        "time": 295,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 295
+        }
+      },
+      {
+        "_id": "3992b6c18de10eafd7a9fb858b631409",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.2@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"d01725fc-4857-4497-a164-a02e2bccb979\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4257e94a20ec-AMS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:47 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-PuV1CLib6G3maHeLBa3fTjaDEjA\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:47.097Z",
+        "time": 250,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 250
+        }
+      },
+      {
+        "_id": "8a32051f412d38ec6dc1a5ba4bccb743",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.3@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"23823ba1-97ff-42ce-a616-f0a01c91661b\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d42597cb659ad-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:47 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-AHAbSxWZBHAkrA+AQYZiYZy1YF4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:47.349Z",
+        "time": 263,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 263
+        }
+      },
+      {
+        "_id": "15475358f2932c7d01b46ee9fe2d325e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.4@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"f74a70f7-f092-47c9-a157-54dd756e81cb\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d425b2d8820ec-AMS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:48 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-M51W0n/CJm2ESzN/rW1OoaPrIWw\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:47.613Z",
+        "time": 290,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 290
+        }
+      },
+      {
+        "_id": "875ec1f3941cbb647f1e2c2772a37a39",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.5@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"44871cdd-cb38-4e2a-b675-6592bbc85847\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d425ce94759ad-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:48 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-dwchW+Sj/l6KMeBPd710JpAchQQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:47.905Z",
+        "time": 295,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 295
+        }
+      },
+      {
+        "_id": "c353ff45782a7b7403d589cd55682a80",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 179,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "limit",
+              "value": "5"
+            }
+          ],
+          "url": "https://api.resend.com/contacts?limit=5"
+        },
+        "response": {
+          "bodySize": 920,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 920,
+            "text": "{\"object\":\"list\",\"has_more\":true,\"data\":[{\"id\":\"d01725fc-4857-4497-a164-a02e2bccb979\",\"created_at\":\"2025-11-30 20:41:40.84216+00\",\"email\":\"test.2@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null},{\"id\":\"44871cdd-cb38-4e2a-b675-6592bbc85847\",\"created_at\":\"2025-11-30 20:39:58.758559+00\",\"email\":\"test.5@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null},{\"id\":\"92e3a543-ba27-4c62-bc22-68247e51b244\",\"created_at\":\"2025-11-30 20:39:57.676578+00\",\"email\":\"test.1@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null},{\"id\":\"f74a70f7-f092-47c9-a157-54dd756e81cb\",\"created_at\":\"2025-11-30 20:39:56.540302+00\",\"email\":\"test.4@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null},{\"id\":\"23823ba1-97ff-42ce-a616-f0a01c91661b\",\"created_at\":\"2025-11-30 20:39:56.23288+00\",\"email\":\"test.3@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d425eda5b20ec-AMS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:48 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"398-3+6j8wlE8LuAkQyEWmB6A4y6svM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 373,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:48.204Z",
+        "time": 228,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 228
+        }
+      },
+      {
+        "_id": "fd2974851b26b8ce315c23f088bec253",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts/test.0@example.com"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 84,
+            "text": "{\"object\":\"contact\",\"contact\":\"32cd6208-6e08-40b9-bdfe-0b5d6d6ce37b\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d42606c5b20ec-AMS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:49 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"54-WOcJM8Qq+1bpXUPZi9U9zjFpGjk\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:48.435Z",
+        "time": 285,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 285
+        }
+      },
+      {
+        "_id": "69a064858f7083d596b68bf10c7b4e15",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts/test.1@example.com"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 84,
+            "text": "{\"object\":\"contact\",\"contact\":\"92e3a543-ba27-4c62-bc22-68247e51b244\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d42605c9f59ad-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:49 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"54-MouH/7RwAr7EHID7YdcDnmWDBsQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:48.435Z",
+        "time": 298,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 298
+        }
+      },
+      {
+        "_id": "240a6cdb2ec44eaf21353e0906a584a8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts/test.3@example.com"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 84,
+            "text": "{\"object\":\"contact\",\"contact\":\"23823ba1-97ff-42ce-a616-f0a01c91661b\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4260eba2ed24-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:49 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"54-Mg4Jn0RQ8i4jocCiAJxw6AyGRGk\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "94"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:48.435Z",
+        "time": 400,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 400
+        }
+      },
+      {
+        "_id": "adaeecea4b790fc22130ec9b481f7779",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts/test.2@example.com"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 84,
+            "text": "{\"object\":\"contact\",\"contact\":\"d01725fc-4857-4497-a164-a02e2bccb979\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4260ac2e9985-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:49 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"54-p6fsHmRNY9iQXBrcTiNxWG7/Kn4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "95"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:48.435Z",
+        "time": 400,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 400
+        }
+      },
+      {
+        "_id": "abd9a89453032e862648222f56d0ebbe",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts/test.4@example.com"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 84,
+            "text": "{\"object\":\"contact\",\"contact\":\"f74a70f7-f092-47c9-a157-54dd756e81cb\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d42612d41fb9b-AMS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:49 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"54-QSrLX+6N3jkX6cs7Ip0ZTxmT3Dw\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "93"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:48.435Z",
+        "time": 431,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 431
+        }
+      },
+      {
+        "_id": "74f4c79f241eeb3137517a147a9122f2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts/test.5@example.com"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 84,
+            "text": "{\"object\":\"contact\",\"contact\":\"44871cdd-cb38-4e2a-b675-6592bbc85847\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d42613ce3e9e9-MRS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:49 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"54-qbHjZgUNgNX3GWcZKae8H62k6Fo\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "92"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:48.435Z",
+        "time": 740,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 740
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-list-lists-contacts-without-pagination_1642863751/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-list-lists-contacts-without-pagination_1642863751/recording.har
@@ -1,0 +1,769 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > list > lists contacts without pagination",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "83e58161ced06c05af0cc1f63153593f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.0@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"32cd6208-6e08-40b9-bdfe-0b5d6d6ce37b\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4240d81520ec-AMS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:44 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-oCf0ZoThdabXPeMRR8OgTcY0+0s\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:43.250Z",
+        "time": 447,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 447
+        }
+      },
+      {
+        "_id": "2dbb7c24904530ede9712e7bcd591940",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.1@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"92e3a543-ba27-4c62-bc22-68247e51b244\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d42435b8559ad-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:44 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-1haCgo5fg1x9u+1S5MnhWRDWvdQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:43.699Z",
+        "time": 757,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 757
+        }
+      },
+      {
+        "_id": "3992b6c18de10eafd7a9fb858b631409",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.2@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"d01725fc-4857-4497-a164-a02e2bccb979\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d42478a1020ec-AMS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:45 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-PuV1CLib6G3maHeLBa3fTjaDEjA\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:44.458Z",
+        "time": 590,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 590
+        }
+      },
+      {
+        "_id": "8a32051f412d38ec6dc1a5ba4bccb743",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.3@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"23823ba1-97ff-42ce-a616-f0a01c91661b\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d424b3c6959ad-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:45 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-AHAbSxWZBHAkrA+AQYZiYZy1YF4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:45.050Z",
+        "time": 596,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 596
+        }
+      },
+      {
+        "_id": "15475358f2932c7d01b46ee9fe2d325e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.4@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"f74a70f7-f092-47c9-a157-54dd756e81cb\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d424edcaf20ec-AMS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:46 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-M51W0n/CJm2ESzN/rW1OoaPrIWw\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:45.648Z",
+        "time": 339,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 339
+        }
+      },
+      {
+        "_id": "875ec1f3941cbb647f1e2c2772a37a39",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.5@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"44871cdd-cb38-4e2a-b675-6592bbc85847\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d42510a9d59ad-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:46 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-dwchW+Sj/l6KMeBPd710JpAchQQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:45.989Z",
+        "time": 302,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 302
+        }
+      },
+      {
+        "_id": "596194f34004515dda40d9c1fa25cab6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 171,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 1097,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1097,
+            "text": "{\"object\":\"list\",\"has_more\":false,\"data\":[{\"id\":\"d01725fc-4857-4497-a164-a02e2bccb979\",\"created_at\":\"2025-11-30 20:41:40.84216+00\",\"email\":\"test.2@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null},{\"id\":\"44871cdd-cb38-4e2a-b675-6592bbc85847\",\"created_at\":\"2025-11-30 20:39:58.758559+00\",\"email\":\"test.5@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null},{\"id\":\"92e3a543-ba27-4c62-bc22-68247e51b244\",\"created_at\":\"2025-11-30 20:39:57.676578+00\",\"email\":\"test.1@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null},{\"id\":\"f74a70f7-f092-47c9-a157-54dd756e81cb\",\"created_at\":\"2025-11-30 20:39:56.540302+00\",\"email\":\"test.4@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null},{\"id\":\"23823ba1-97ff-42ce-a616-f0a01c91661b\",\"created_at\":\"2025-11-30 20:39:56.23288+00\",\"email\":\"test.3@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null},{\"id\":\"32cd6208-6e08-40b9-bdfe-0b5d6d6ce37b\",\"created_at\":\"2025-11-30 20:39:55.248188+00\",\"email\":\"test.0@example.com\",\"unsubscribed\":false,\"first_name\":null,\"last_name\":null}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4252ea7c20ec-AMS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:46 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"449-hJefYgGfMX76Bwnarbi6il8LhvA\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 373,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:46.294Z",
+        "time": 180,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 180
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-remove-appears-to-remove-a-contact-that-_3680402516/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-remove-appears-to-remove-a-contact-that-_3680402516/recording.har
@@ -1,0 +1,336 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > remove > appears to remove a contact that never existed",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ee2505e9b6f3bd72f62eddbed4ddd680",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 49,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for non-existent delete 1\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 112,
+            "text": "{\"object\":\"segment\",\"id\":\"be909ad7-a393-4242-9208-481f7565f7ee\",\"name\":\"Test segment for non-existent delete 1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40d72e6aeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "112"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:46 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"70-j5DXN7W2OQwrQI5BRfLN/j8+XgI\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:45.537Z",
+        "time": 176,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 176
+        }
+      },
+      {
+        "_id": "e3bad8fa674d7062fb7c16818eb193f9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 258,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/be909ad7-a393-4242-9208-481f7565f7ee/contacts/00000000-0000-0000-0000-000000000000"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 84,
+            "text": "{\"object\":\"contact\",\"contact\":\"00000000-0000-0000-0000-000000000000\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40d83b03edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:46 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"54-rfEgMCeqSJYc1agGuHEGmuCuACI\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "95"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:45.715Z",
+        "time": 188,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 188
+        }
+      },
+      {
+        "_id": "05a7cccd733d818d1d75f530d69c2931",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/be909ad7-a393-4242-9208-481f7565f7ee"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"be909ad7-a393-4242-9208-481f7565f7ee\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40d97cafeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:46 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-Wkdq0711CGnSo8B76VigvHiqLgE\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:45.904Z",
+        "time": 256,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 256
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-remove-removes-a-contact-by-email_421891524/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-remove-removes-a-contact-by-email_421891524/recording.har
@@ -1,0 +1,551 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > remove > removes a contact by email",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "24e7a9a54c7f84050ada8d4a153e9b44",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 45,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for remove by email 1\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 108,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 108,
+            "text": "{\"object\":\"segment\",\"id\":\"d6a1792a-0a97-41aa-a3dd-7ebec2becceb\",\"name\":\"Test segment for remove by email 1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40cf69f3eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "108"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:44 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"6c-7+rTxvd2FfeLYL5hDN7NZ/Gaj5s\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:44.304Z",
+        "time": 171,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 171
+        }
+      },
+      {
+        "_id": "d6525a9958d57daf57b1af3fe7f3ca6c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 44,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test-remove-by-email@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/d6a1792a-0a97-41aa-a3dd-7ebec2becceb/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"c90700db-815a-4edd-a72e-853a31ea12c9\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40d09f47edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:45 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-uHpbg42nT0aid5LukEY8BkA7rRQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:44.477Z",
+        "time": 344,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 344
+        }
+      },
+      {
+        "_id": "8bd97c70e6262ff3457e940564a57c1d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/d6a1792a-0a97-41aa-a3dd-7ebec2becceb/contacts/test-remove-by-email@example.com"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 80,
+            "text": "{\"object\":\"contact\",\"contact\":\"test-remove-by-email@example.com\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40d2aad3eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:45 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"50-Xsi7eJcodAoVMeQ8sbTFSvP7E3I\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:44.822Z",
+        "time": 262,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 262
+        }
+      },
+      {
+        "_id": "2a82fb0d94b4d030d83a97cac5ebec39",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 251,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/d6a1792a-0a97-41aa-a3dd-7ebec2becceb/contacts/test-remove-by-email@example.com"
+        },
+        "response": {
+          "bodySize": 67,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 67,
+            "text": "{\"statusCode\":404,\"message\":\"Contact not found\",\"name\":\"not_found\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40d45f40eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:45 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"43-Hlm9sCxABe1C/S9NDIZg0PaqfAM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2025-11-30T20:56:45.085Z",
+        "time": 168,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 168
+        }
+      },
+      {
+        "_id": "047ce90a96272505d905a9aa44984d67",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/d6a1792a-0a97-41aa-a3dd-7ebec2becceb"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"d6a1792a-0a97-41aa-a3dd-7ebec2becceb\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40d56a07eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:45 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-OjF84ZE2G6S0ag6k3U+euxLVfhw\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:45.254Z",
+        "time": 278,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 278
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-remove-removes-a-contact-by-id_1448282337/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-remove-removes-a-contact-by-id_1448282337/recording.har
@@ -1,0 +1,551 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > remove > removes a contact by id",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "a08613c26d3136750d0e41fc41331f6d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 42,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for remove by ID 1\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 105,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 105,
+            "text": "{\"object\":\"segment\",\"id\":\"5ec24658-7666-49a8-88d1-55e67e8611ff\",\"name\":\"Test segment for remove by ID 1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40c688f7eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "105"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:43 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"69-75sLf90mObaqQIlYgIMDAyTBwHk\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:42.889Z",
+        "time": 160,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 160
+        }
+      },
+      {
+        "_id": "497bed558e781af35ec59befcaf170e7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 41,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test-remove-by-id@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/5ec24658-7666-49a8-88d1-55e67e8611ff/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"1e26f80e-8034-4277-a26f-71a2c889c5dc\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40c79e07edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:43 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-9L7E7mgD0EN4JHEkx2VSA88YHWQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:43.050Z",
+        "time": 413,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 413
+        }
+      },
+      {
+        "_id": "a9b4c8c447790cba1332ec6cf4033a64",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 258,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/5ec24658-7666-49a8-88d1-55e67e8611ff/contacts/1e26f80e-8034-4277-a26f-71a2c889c5dc"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 84,
+            "text": "{\"object\":\"contact\",\"contact\":\"1e26f80e-8034-4277-a26f-71a2c889c5dc\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40ca2af3eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:44 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"54-Tg1RLnQB0cz/CSlhomI3GglJ1A8\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:43.465Z",
+        "time": 270,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 270
+        }
+      },
+      {
+        "_id": "59b8c61362c8e8739a8262248164b89b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 255,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/5ec24658-7666-49a8-88d1-55e67e8611ff/contacts/1e26f80e-8034-4277-a26f-71a2c889c5dc"
+        },
+        "response": {
+          "bodySize": 67,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 67,
+            "text": "{\"statusCode\":404,\"message\":\"Contact not found\",\"name\":\"not_found\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40cbdfc3eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:44 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"43-Hlm9sCxABe1C/S9NDIZg0PaqfAM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2025-11-30T20:56:43.736Z",
+        "time": 174,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 174
+        }
+      },
+      {
+        "_id": "48acf343bfa10c15fe92d34ed34265db",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/5ec24658-7666-49a8-88d1-55e67e8611ff"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"5ec24658-7666-49a8-88d1-55e67e8611ff\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40ccfb99eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:44 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-T5eYdNHnnMm9xDys70tdQXw3K1s\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:43.911Z",
+        "time": 386,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 386
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-update-updates-a-contact_2952799553/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-contacts-API-endpoint-update-updates-a-contact_2952799553/recording.har
@@ -1,0 +1,556 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > contacts API endpoint > update > updates a contact",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "ba2a557863a7d005f9095b5465588bb3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 36,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for update 1\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 99,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 99,
+            "text": "{\"object\":\"segment\",\"id\":\"05281acd-6502-4401-a689-85684e56bd91\",\"name\":\"Test segment for update 1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40bccdeceea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "99"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:41 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"63-1QYCDrSSJcNFtWfVYqIfNwodGEM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:41.293Z",
+        "time": 193,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 193
+        }
+      },
+      {
+        "_id": "41e46e2010a4d68b785165fe1fe3eb19",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 35,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test-update@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/05281acd-6502-4401-a689-85684e56bd91/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"15d96bf0-0778-43dd-beb0-e5fcbed098e3\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40bdfbb5edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:42 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-Q/0oZD7kpL8/FoPah8p9wiyZ8mE\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:41.488Z",
+        "time": 411,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 411
+        }
+      },
+      {
+        "_id": "6b0841cf5b316de72b723eaf7184815f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 43,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 257,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"first_name\":\"Updated\",\"last_name\":\"Name\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/05281acd-6502-4401-a689-85684e56bd91/contacts/15d96bf0-0778-43dd-beb0-e5fcbed098e3"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"15d96bf0-0778-43dd-beb0-e5fcbed098e3\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40c06fc5eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:42 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-Q/0oZD7kpL8/FoPah8p9wiyZ8mE\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:41.904Z",
+        "time": 258,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 258
+        }
+      },
+      {
+        "_id": "be7bf45f336dcb329f3812679bb280e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 255,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/05281acd-6502-4401-a689-85684e56bd91/contacts/15d96bf0-0778-43dd-beb0-e5fcbed098e3"
+        },
+        "response": {
+          "bodySize": 221,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 221,
+            "text": "{\"object\":\"contact\",\"id\":\"15d96bf0-0778-43dd-beb0-e5fcbed098e3\",\"email\":\"test-update@example.com\",\"first_name\":\"Updated\",\"last_name\":\"Name\",\"created_at\":\"2025-11-30 20:42:46.04984+00\",\"unsubscribed\":false,\"properties\":{}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40c21c3beea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:42 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"dd-L91hOY+yQbKHr0sVOOitwE7S8Qc\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:42.163Z",
+        "time": 440,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 440
+        }
+      },
+      {
+        "_id": "36996b08e71e3ff37c01d3177d3d22c2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/05281acd-6502-4401-a689-85684e56bd91"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"05281acd-6502-4401-a689-85684e56bd91\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40c4dc0aeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:43 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-i88QMX2CUcNEUPuQN2ewmxRx69E\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:42.604Z",
+        "time": 278,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 278
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-create-creates-a-contact_2105949324/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-create-creates-a-contact_2105949324/recording.har
@@ -1,0 +1,337 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > create > creates a contact",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "4f9821c7b064673b64a3d2e6c10dad1a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 46,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for contact creation 2\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 109,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 109,
+            "text": "{\"object\":\"segment\",\"id\":\"49f98685-5956-4f85-96f0-ac706edbac5b\",\"name\":\"Test segment for contact creation 2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40db08e1eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "109"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:46 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"6d-Zks4KfiAlVbaRf1M/8YCx76eQ4U\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:46.164Z",
+        "time": 187,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 187
+        }
+      },
+      {
+        "_id": "8362b9e63080065fcf6f31776f16b013",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 67,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test@example.com\",\"first_name\":\"Test\",\"last_name\":\"User\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/49f98685-5956-4f85-96f0-ac706edbac5b/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"bacce9f0-7193-41b9-baf1-ad060e1be3f4\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40dc4e68edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:47 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-6WWYp42MZkMf/Scy3lJPR3GRAH0\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:46.352Z",
+        "time": 393,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 393
+        }
+      },
+      {
+        "_id": "2376ab05ce27c6f218823ea0583e50ed",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/49f98685-5956-4f85-96f0-ac706edbac5b"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"49f98685-5956-4f85-96f0-ac706edbac5b\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40deaa7aeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:47 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-F9uG/tHDWaw06wWEUYerY9PL+tk\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:46.746Z",
+        "time": 244,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 244
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-create-handles-validation-errors_2001818523/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-create-handles-validation-errors_2001818523/recording.har
@@ -1,0 +1,122 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > create > handles validation errors",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "7e36d93bf833d78073dab4d08fb175ea",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/contacts"
+        },
+        "response": {
+          "bodySize": 85,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 85,
+            "text": "{\"statusCode\":422,\"message\":\"Missing `email` field.\",\"name\":\"missing_required_field\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40e04e95eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "85"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:47 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"55-3twEi8WnC2GKqaYdAl7cGsmeByc\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 422,
+          "statusText": "Unprocessable Entity"
+        },
+        "startedDateTime": "2025-11-30T20:56:46.996Z",
+        "time": 160,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 160
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-get-retrieves-a-contact-by-email_321416205/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-get-retrieves-a-contact-by-email_321416205/recording.har
@@ -1,0 +1,444 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > get > retrieves a contact by email",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "b6434a9b8835188694e686780b261650",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 39,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for get by ID 2\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 102,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 102,
+            "text": "{\"object\":\"segment\",\"id\":\"64d16b38-507a-4d73-9bd9-7cbd64abbe3e\",\"name\":\"Test segment for get by ID 2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41107fbfeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "102"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:55 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"66-hOP8+ODN6/qsv7JSVEwrxqAXMgM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:54.712Z",
+        "time": 181,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 181
+        }
+      },
+      {
+        "_id": "e19d3e8bd9c41160487d8c5486977cfd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 41,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test-get-by-email@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/64d16b38-507a-4d73-9bd9-7cbd64abbe3e/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"7c8272c4-ed16-4d01-8202-17fb3b1a04ea\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41119a88edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:55 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-heiKa1R1sYWT2rhn3Pu5CpmYVTc\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:54.894Z",
+        "time": 430,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 430
+        }
+      },
+      {
+        "_id": "70c5e9377d072322ddac67f0c0bd118a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 201,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/contacts/test-get-by-email@example.com"
+        },
+        "response": {
+          "bodySize": 221,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 221,
+            "text": "{\"object\":\"contact\",\"id\":\"7c8272c4-ed16-4d01-8202-17fb3b1a04ea\",\"email\":\"test-get-by-email@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:59.540771+00\",\"unsubscribed\":false,\"properties\":{}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d411449baeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:55 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"dd-qIzaKtcamGT6J9ousJWHXCIKORI\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:55.325Z",
+        "time": 168,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 168
+        }
+      },
+      {
+        "_id": "38287f652e02a4cdfb6b6dfcdf0adccf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/64d16b38-507a-4d73-9bd9-7cbd64abbe3e"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"64d16b38-507a-4d73-9bd9-7cbd64abbe3e\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41155ccceea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:56 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-lunl3v11Hbyguyz8BNQqyQEg2j4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:55.495Z",
+        "time": 315,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 315
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-get-retrieves-a-contact-by-id_916474674/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-get-retrieves-a-contact-by-id_916474674/recording.har
@@ -1,0 +1,444 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > get > retrieves a contact by id",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "b6434a9b8835188694e686780b261650",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 39,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for get by ID 2\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 102,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 102,
+            "text": "{\"object\":\"segment\",\"id\":\"4da58fea-b205-494c-817a-0a4a3be7139f\",\"name\":\"Test segment for get by ID 2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d410a3d4feea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "102"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:54 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"66-C8ds1Am4HDI8pf3XczwLn3AsxgA\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:53.709Z",
+        "time": 172,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 172
+        }
+      },
+      {
+        "_id": "cbc800e185b519040db78d2f6e529b7b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 38,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test-get-by-id@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/4da58fea-b205-494c-817a-0a4a3be7139f/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"e242c221-be74-4ff4-b8dc-0efb234dd6a1\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d410b59ecedbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:54 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-Db1lRTfeXvUi9lYlVNxnF6X7jJ4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "95"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:53.881Z",
+        "time": 392,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 392
+        }
+      },
+      {
+        "_id": "9ec35366859ef39dc2339f35c86357c0",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 255,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/4da58fea-b205-494c-817a-0a4a3be7139f/contacts/e242c221-be74-4ff4-b8dc-0efb234dd6a1"
+        },
+        "response": {
+          "bodySize": 218,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 218,
+            "text": "{\"object\":\"contact\",\"id\":\"e242c221-be74-4ff4-b8dc-0efb234dd6a1\",\"email\":\"test-get-by-id@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:41:44.782119+00\",\"unsubscribed\":false,\"properties\":{}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d410dbfa8eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:54 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"da-irFfqWd48pWyj0zzbPbauK/FSe4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:54.275Z",
+        "time": 196,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 196
+        }
+      },
+      {
+        "_id": "3f1bd2bf2196d9beace3eedfebf8ead9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/4da58fea-b205-494c-817a-0a4a3be7139f"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"4da58fea-b205-494c-817a-0a4a3be7139f\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d410f0b86eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:55 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-HYZNcFGi1IHzAU+Uc//eglFOKJM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:54.473Z",
+        "time": 233,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 233
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-get-returns-error-for-non-existen_3073019458/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-get-returns-error-for-non-existen_3073019458/recording.har
@@ -1,0 +1,336 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > get > returns error for non-existent contact",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "b6434a9b8835188694e686780b261650",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 39,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for get by ID 2\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 102,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 102,
+            "text": "{\"object\":\"segment\",\"id\":\"1543dae2-d87a-4191-8bfd-68e9a6caf319\",\"name\":\"Test segment for get by ID 2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41176aa3eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "102"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:56 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"66-qxt+Mjj77F0RkUEVzyAO/jfJ0FE\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:55.814Z",
+        "time": 205,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 205
+        }
+      },
+      {
+        "_id": "563dd05e5b0088efedb2f99234820487",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 255,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/1543dae2-d87a-4191-8bfd-68e9a6caf319/contacts/00000000-0000-0000-0000-000000000000"
+        },
+        "response": {
+          "bodySize": 67,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 67,
+            "text": "{\"statusCode\":404,\"message\":\"Contact not found\",\"name\":\"not_found\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4118ae47edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:56 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"43-Hlm9sCxABe1C/S9NDIZg0PaqfAM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2025-11-30T20:56:56.019Z",
+        "time": 187,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 187
+        }
+      },
+      {
+        "_id": "40f042ccdfb22b91bab82cf8005a7e7f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/1543dae2-d87a-4191-8bfd-68e9a6caf319"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"1543dae2-d87a-4191-8bfd-68e9a6caf319\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4119c967eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:57 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-gVs6NjhKi20hYl0n5QaPs3qcjvA\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:56.207Z",
+        "time": 744,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 744
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-list-lists-contacts-with-limit_2917087187/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-list-lists-contacts-with-limit_2917087187/recording.har
@@ -1,0 +1,989 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > list > lists contacts with limit",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "1a2859db7b4b2a6934899dcc528bf176",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 48,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for listing with limit 2\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 111,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 111,
+            "text": "{\"object\":\"segment\",\"id\":\"89c892a2-abca-4ac7-a744-06fcb67202cb\",\"name\":\"Test segment for listing with limit 2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40f75da1eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "111"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:51 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"6f-pBqXGofSsYATNAduaPV/JdhZGtk\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:50.669Z",
+        "time": 198,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 198
+        }
+      },
+      {
+        "_id": "fc7d68fd812151f5cccb9fc3e1787e34",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.0@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/89c892a2-abca-4ac7-a744-06fcb67202cb/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"32cd6208-6e08-40b9-bdfe-0b5d6d6ce37b\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40f87e5dedbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:51 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-oCf0ZoThdabXPeMRR8OgTcY0+0s\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:50.869Z",
+        "time": 424,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 424
+        }
+      },
+      {
+        "_id": "cc504e35dedb28d80ad9ea4039540b08",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.1@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/89c892a2-abca-4ac7-a744-06fcb67202cb/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"92e3a543-ba27-4c62-bc22-68247e51b244\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40fb19f5eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:52 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-1haCgo5fg1x9u+1S5MnhWRDWvdQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:51.295Z",
+        "time": 366,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 366
+        }
+      },
+      {
+        "_id": "2c6d6afd9a51807d6c63dc9f5ef070ff",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.2@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/89c892a2-abca-4ac7-a744-06fcb67202cb/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"d01725fc-4857-4497-a164-a02e2bccb979\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40fd6cc4edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:52 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-PuV1CLib6G3maHeLBa3fTjaDEjA\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:51.662Z",
+        "time": 388,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 388
+        }
+      },
+      {
+        "_id": "7c2c9d164ab09d36abf20bca98966bce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.3@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/89c892a2-abca-4ac7-a744-06fcb67202cb/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"23823ba1-97ff-42ce-a616-f0a01c91661b\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40ffdfbfeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:52 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-AHAbSxWZBHAkrA+AQYZiYZy1YF4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:52.051Z",
+        "time": 411,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 411
+        }
+      },
+      {
+        "_id": "d15c9473287b66819c238907e4d4c35e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.4@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/89c892a2-abca-4ac7-a744-06fcb67202cb/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"f74a70f7-f092-47c9-a157-54dd756e81cb\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41026a92edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:53 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-M51W0n/CJm2ESzN/rW1OoaPrIWw\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:52.463Z",
+        "time": 424,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 424
+        }
+      },
+      {
+        "_id": "0e8750e2a5f48c98b6cec5db0b412726",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.5@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/89c892a2-abca-4ac7-a744-06fcb67202cb/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"44871cdd-cb38-4e2a-b675-6592bbc85847\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41052e8eeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:53 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-dwchW+Sj/l6KMeBPd710JpAchQQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:52.888Z",
+        "time": 380,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 380
+        }
+      },
+      {
+        "_id": "1d533d00137b962e282ba01c68dc877c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 225,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "limit",
+              "value": "5"
+            }
+          ],
+          "url": "https://api.resend.com/segments/89c892a2-abca-4ac7-a744-06fcb67202cb/contacts?limit=5"
+        },
+        "response": {
+          "bodySize": 920,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 920,
+            "text": "{\"object\":\"list\",\"has_more\":true,\"data\":[{\"id\":\"d01725fc-4857-4497-a164-a02e2bccb979\",\"email\":\"test.2@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:41:40.84216+00\",\"unsubscribed\":false},{\"id\":\"44871cdd-cb38-4e2a-b675-6592bbc85847\",\"email\":\"test.5@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:58.758559+00\",\"unsubscribed\":false},{\"id\":\"92e3a543-ba27-4c62-bc22-68247e51b244\",\"email\":\"test.1@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:57.676578+00\",\"unsubscribed\":false},{\"id\":\"f74a70f7-f092-47c9-a157-54dd756e81cb\",\"email\":\"test.4@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:56.540302+00\",\"unsubscribed\":false},{\"id\":\"23823ba1-97ff-42ce-a616-f0a01c91661b\",\"email\":\"test.3@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:56.23288+00\",\"unsubscribed\":false}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41077fc7edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:53 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"398-ohyvS7zoGvUzbePD/TE6lUgJipU\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 373,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:53.271Z",
+        "time": 171,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 171
+        }
+      },
+      {
+        "_id": "bb0e2cd541d62689d7cf3160e81e81d9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/89c892a2-abca-4ac7-a744-06fcb67202cb"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"89c892a2-abca-4ac7-a744-06fcb67202cb\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4108983deea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:54 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-JJ4+XDOtp4Iws/CZJ2pALikhcBA\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:53.444Z",
+        "time": 256,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 256
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-list-lists-contacts-without-pagin_2517758764/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-list-lists-contacts-without-pagin_2517758764/recording.har
@@ -1,0 +1,1626 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > list > lists contacts without pagination",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "64d8f7ede42b49c32fb827e08c784680",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 37,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for listing 2\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 100,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 100,
+            "text": "{\"object\":\"segment\",\"id\":\"3605bc58-a3b3-4dbb-93d5-3461477842c5\",\"name\":\"Test segment for listing 2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40e14d32edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "100"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:47 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"64-ysHnLoRC4IJIKnAGH7Uh31mPt0w\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:47.158Z",
+        "time": 169,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 169
+        }
+      },
+      {
+        "_id": "24cd7786246b1d28766609d7c7704f83",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.0@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"32cd6208-6e08-40b9-bdfe-0b5d6d6ce37b\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40e25bceeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:48 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-oCf0ZoThdabXPeMRR8OgTcY0+0s\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:47.329Z",
+        "time": 362,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 362
+        }
+      },
+      {
+        "_id": "fb75c8d6fdbb5e54e8f5b5c79695eafd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.1@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"92e3a543-ba27-4c62-bc22-68247e51b244\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40e49e7aedbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:48 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-1haCgo5fg1x9u+1S5MnhWRDWvdQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:47.692Z",
+        "time": 365,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 365
+        }
+      },
+      {
+        "_id": "96ae629892fd7e0b4ef07a428b6482f6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.2@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"d01725fc-4857-4497-a164-a02e2bccb979\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40e6efbdeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:48 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-PuV1CLib6G3maHeLBa3fTjaDEjA\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:48.059Z",
+        "time": 366,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 366
+        }
+      },
+      {
+        "_id": "78cd14e6430e5cc9306b54701f6f3c9c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.3@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"23823ba1-97ff-42ce-a616-f0a01c91661b\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40e92bcaedbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:49 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-AHAbSxWZBHAkrA+AQYZiYZy1YF4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:48.426Z",
+        "time": 376,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 376
+        }
+      },
+      {
+        "_id": "951dcacab7dce7e207311eb31af4e7d4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.4@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"f74a70f7-f092-47c9-a157-54dd756e81cb\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40ebac0feea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:49 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-M51W0n/CJm2ESzN/rW1OoaPrIWw\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:48.803Z",
+        "time": 375,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 375
+        }
+      },
+      {
+        "_id": "04f475849842351d5bbd3fb06ea3c3a5",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 30,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test.5@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"44871cdd-cb38-4e2a-b675-6592bbc85847\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40ede8daedbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:49 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-dwchW+Sj/l6KMeBPd710JpAchQQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:49.179Z",
+        "time": 359,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 359
+        }
+      },
+      {
+        "_id": "b428923566e770da3dfbd8a80ee39517",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 217,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts"
+        },
+        "response": {
+          "bodySize": 1097,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1097,
+            "text": "{\"object\":\"list\",\"has_more\":false,\"data\":[{\"id\":\"d01725fc-4857-4497-a164-a02e2bccb979\",\"email\":\"test.2@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:41:40.84216+00\",\"unsubscribed\":false},{\"id\":\"44871cdd-cb38-4e2a-b675-6592bbc85847\",\"email\":\"test.5@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:58.758559+00\",\"unsubscribed\":false},{\"id\":\"92e3a543-ba27-4c62-bc22-68247e51b244\",\"email\":\"test.1@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:57.676578+00\",\"unsubscribed\":false},{\"id\":\"f74a70f7-f092-47c9-a157-54dd756e81cb\",\"email\":\"test.4@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:56.540302+00\",\"unsubscribed\":false},{\"id\":\"23823ba1-97ff-42ce-a616-f0a01c91661b\",\"email\":\"test.3@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:56.23288+00\",\"unsubscribed\":false},{\"id\":\"32cd6208-6e08-40b9-bdfe-0b5d6d6ce37b\",\"email\":\"test.0@example.com\",\"first_name\":null,\"last_name\":null,\"created_at\":\"2025-11-30 20:39:55.248188+00\",\"unsubscribed\":false}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40f02999eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:50 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"449-vZ0pXbSic25RnWV4My/zAh4/rHI\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 373,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:49.540Z",
+        "time": 187,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 187
+        }
+      },
+      {
+        "_id": "eca9243254adafd69fde33210924c2e2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/3605bc58-a3b3-4dbb-93d5-3461477842c5"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"3605bc58-a3b3-4dbb-93d5-3461477842c5\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40f15d12eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:50 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-x8085Y57Agw94EemL0YRqIhjD5s\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:49.729Z",
+        "time": 235,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 235
+        }
+      },
+      {
+        "_id": "e6dad607950752c2078e898bdd4c6d91",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts/test.0@example.com"
+        },
+        "response": {
+          "bodySize": 66,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 66,
+            "text": "{\"object\":\"contact\",\"contact\":\"test.0@example.com\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40f2d8e5eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:50 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"42-5iQ3paH/gL1j8DgYz3GBbRoIbzY\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:49.967Z",
+        "time": 279,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 279
+        }
+      },
+      {
+        "_id": "5fd6a4fa5d29673a67d6b473efefea3c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts/test.1@example.com"
+        },
+        "response": {
+          "bodySize": 66,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 66,
+            "text": "{\"object\":\"contact\",\"contact\":\"test.1@example.com\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40f2ce83edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:50 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"42-qSJKfU1eRpNRFtwm4jq7hHn9gzM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "95"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:49.967Z",
+        "time": 280,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 280
+        }
+      },
+      {
+        "_id": "fa6841484d3965347b0980d542394376",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts/test.3@example.com"
+        },
+        "response": {
+          "bodySize": 66,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 66,
+            "text": "{\"object\":\"contact\",\"contact\":\"test.3@example.com\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40f36a95edaa-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:50 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"42-o9uLWblhdy1nYYA3eoj7aKEl4Xg\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "94"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:49.967Z",
+        "time": 362,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 362
+        }
+      },
+      {
+        "_id": "83d0c736d17f6c7237f36db4454808d5",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts/test.2@example.com"
+        },
+        "response": {
+          "bodySize": 66,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 66,
+            "text": "{\"object\":\"contact\",\"contact\":\"test.2@example.com\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40f37839ed4f-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:50 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"42-52euSAczFQEifjMVet3gvXQcZ3g\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "93"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:49.967Z",
+        "time": 394,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 394
+        }
+      },
+      {
+        "_id": "b2ebc55a8787ab89239931845f9e471c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts/test.5@example.com"
+        },
+        "response": {
+          "bodySize": 66,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 66,
+            "text": "{\"object\":\"contact\",\"contact\":\"test.5@example.com\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40f37db06db2-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:50 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"42-wql23isDVLbGXE/vdZPSz+GhHH8\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "92"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:49.967Z",
+        "time": 396,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 396
+        }
+      },
+      {
+        "_id": "59daebbccb9eb94cead16d1a81e639bf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 240,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/3605bc58-a3b3-4dbb-93d5-3461477842c5/contacts/test.4@example.com"
+        },
+        "response": {
+          "bodySize": 66,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 66,
+            "text": "{\"object\":\"contact\",\"contact\":\"test.4@example.com\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d40f3abed83cc-MRS"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:51 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"42-5+9S/SAI+RXuIYqmjK03CTcMTrE\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:49.967Z",
+        "time": 696,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 696
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-remove-appears-to-remove-a-contac_1201904625/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-remove-appears-to-remove-a-contac_1201904625/recording.har
@@ -1,0 +1,336 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > remove > appears to remove a contact that never existed",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "e6d03079bb283d8b85cc77fb094c3dd7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 49,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for non-existent delete 2\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 112,
+            "text": "{\"object\":\"segment\",\"id\":\"24d9116a-e116-4590-b2b2-0f56eb069e43\",\"name\":\"Test segment for non-existent delete 2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d413b9ae8eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "112"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:02 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"70-nzoFetnZ49UW4f/9EOYPtwel78s\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:01.617Z",
+        "time": 274,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 274
+        }
+      },
+      {
+        "_id": "a9ecb50c36f763dabe80375440e8fe0f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 258,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/24d9116a-e116-4590-b2b2-0f56eb069e43/contacts/00000000-0000-0000-0000-000000000000"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 84,
+            "text": "{\"object\":\"contact\",\"contact\":\"00000000-0000-0000-0000-000000000000\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d413d6b61edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:02 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"54-rfEgMCeqSJYc1agGuHEGmuCuACI\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:01.891Z",
+        "time": 192,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 192
+        }
+      },
+      {
+        "_id": "3e45c33e02fc8adc0f409b0b176a6ec3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/24d9116a-e116-4590-b2b2-0f56eb069e43"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"24d9116a-e116-4590-b2b2-0f56eb069e43\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d413e8a6feea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:02 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-thahkl4SukroMIZCcGUwu35oWvg\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:02.084Z",
+        "time": 412,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 412
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-remove-removes-a-contact-by-email_1387333173/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-remove-removes-a-contact-by-email_1387333173/recording.har
@@ -1,0 +1,551 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > remove > removes a contact by email",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "24480380320a1e979ee060d7475b4f3d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 45,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for remove by email 2\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 108,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 108,
+            "text": "{\"object\":\"segment\",\"id\":\"583da88a-79b0-407c-bb33-fe6b79487754\",\"name\":\"Test segment for remove by email 2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4130fc23eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "108"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:00 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"6c-BQfe8udAIt6QLDg4PF5+Yp6+hs8\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:59.901Z",
+        "time": 499,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 499
+        }
+      },
+      {
+        "_id": "90622d316027c7f1f30cafe5f841b8fb",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 44,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test-remove-by-email@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/583da88a-79b0-407c-bb33-fe6b79487754/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"c90700db-815a-4edd-a72e-853a31ea12c9\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41340ef4edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:01 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-uHpbg42nT0aid5LukEY8BkA7rRQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:57:00.401Z",
+        "time": 512,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 512
+        }
+      },
+      {
+        "_id": "1fad80e2a22ff503e5f44f022f93de00",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 254,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/583da88a-79b0-407c-bb33-fe6b79487754/contacts/test-remove-by-email@example.com"
+        },
+        "response": {
+          "bodySize": 80,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 80,
+            "text": "{\"object\":\"contact\",\"contact\":\"test-remove-by-email@example.com\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41373e43eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:01 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"50-Xsi7eJcodAoVMeQ8sbTFSvP7E3I\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:00.914Z",
+        "time": 274,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 274
+        }
+      },
+      {
+        "_id": "bfb41970ab8f65d8dc3d5fe083c888f3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 251,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/583da88a-79b0-407c-bb33-fe6b79487754/contacts/test-remove-by-email@example.com"
+        },
+        "response": {
+          "bodySize": 67,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 67,
+            "text": "{\"statusCode\":404,\"message\":\"Contact not found\",\"name\":\"not_found\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41390b31eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:01 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"43-Hlm9sCxABe1C/S9NDIZg0PaqfAM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2025-11-30T20:57:01.189Z",
+        "time": 183,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 183
+        }
+      },
+      {
+        "_id": "4c34f1bbde2e4775b285871a330f5e06",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/583da88a-79b0-407c-bb33-fe6b79487754"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"583da88a-79b0-407c-bb33-fe6b79487754\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d413a1e1feea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:01 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-/bIllBj/d16RYWpN4K5xdi83pdg\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:57:01.374Z",
+        "time": 236,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 236
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-remove-removes-a-contact-by-id_2752430570/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-remove-removes-a-contact-by-id_2752430570/recording.har
@@ -1,0 +1,551 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > remove > removes a contact by id",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "b7a315ea2d2a19e87e1fc12e472adad8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 42,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for remove by ID 2\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 105,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 105,
+            "text": "{\"object\":\"segment\",\"id\":\"5e7798c6-33ad-406b-9d09-c02b813b31e3\",\"name\":\"Test segment for remove by ID 2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4126b813eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "105"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:58 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"69-mFy0kr4bMKzDJAxOepqGdCUHb1A\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "96"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 343,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:58.255Z",
+        "time": 248,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 248
+        }
+      },
+      {
+        "_id": "b048fda93a647cd0a934388b97ba581b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 41,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test-remove-by-id@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/5e7798c6-33ad-406b-9d09-c02b813b31e3/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"1e26f80e-8034-4277-a26f-71a2c889c5dc\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41282bbaedbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:59 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-9L7E7mgD0EN4JHEkx2VSA88YHWQ\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "95"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:58.506Z",
+        "time": 557,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 557
+        }
+      },
+      {
+        "_id": "e577f3972f8a40d109cacd650d78d647",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 258,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/5e7798c6-33ad-406b-9d09-c02b813b31e3/contacts/1e26f80e-8034-4277-a26f-71a2c889c5dc"
+        },
+        "response": {
+          "bodySize": 84,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 84,
+            "text": "{\"object\":\"contact\",\"contact\":\"1e26f80e-8034-4277-a26f-71a2c889c5dc\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d412bad52eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:59 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"54-Tg1RLnQB0cz/CSlhomI3GglJ1A8\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:59.065Z",
+        "time": 336,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 336
+        }
+      },
+      {
+        "_id": "9633cf6c50d3c3ab875247d48e74d48a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 255,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/5e7798c6-33ad-406b-9d09-c02b813b31e3/contacts/1e26f80e-8034-4277-a26f-71a2c889c5dc"
+        },
+        "response": {
+          "bodySize": 67,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 67,
+            "text": "{\"statusCode\":404,\"message\":\"Contact not found\",\"name\":\"not_found\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d412dcb2aeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:59 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"43-Hlm9sCxABe1C/S9NDIZg0PaqfAM\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2025-11-30T20:56:59.401Z",
+        "time": 177,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 177
+        }
+      },
+      {
+        "_id": "b10f366e790731c2bc39f88520c92db9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/5e7798c6-33ad-406b-9d09-c02b813b31e3"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"5e7798c6-33ad-406b-9d09-c02b813b31e3\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d412f0e99eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:57:00 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-9s/jmQL+63MYdRKEDzqF2w/YAO4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:59.580Z",
+        "time": 317,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 317
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-update-updates-a-contact_2208481482/recording.har
+++ b/src/contacts/__recordings__/Contacts-Integration-Tests-legacy-contacts-API-endpoint-update-updates-a-contact_2208481482/recording.har
@@ -1,0 +1,556 @@
+{
+  "log": {
+    "_recordingName": "Contacts Integration Tests > legacy contacts API endpoint > update > updates a contact",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.6"
+    },
+    "entries": [
+      {
+        "_id": "df81fce002a5b90e6ea20d2d20f1eddc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 36,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 172,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"name\":\"Test segment for update 2\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/segments"
+        },
+        "response": {
+          "bodySize": 99,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 99,
+            "text": "{\"object\":\"segment\",\"id\":\"51e47b84-1614-4bae-8413-3b12a35d5984\",\"name\":\"Test segment for update 2\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d411e8f1aeea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "99"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:57 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"63-/26/ZH5w/+h9NDDHXEGz941H9Wc\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:56.957Z",
+        "time": 189,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 189
+        }
+      },
+      {
+        "_id": "c993a590cec014c59ab29bb6f99c3508",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 35,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 219,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"email\":\"test-update@example.com\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/51e47b84-1614-4bae-8413-3b12a35d5984/contacts"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"15d96bf0-0778-43dd-beb0-e5fcbed098e3\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d411fbb35edbe-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-length",
+              "value": "64"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:57 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-Q/0oZD7kpL8/FoPah8p9wiyZ8mE\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2025-11-30T20:56:57.147Z",
+        "time": 377,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 377
+        }
+      },
+      {
+        "_id": "6af6d217700859512e3d969ad9435245",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 43,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 257,
+          "httpVersion": "HTTP/1.1",
+          "method": "PATCH",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"first_name\":\"Updated\",\"last_name\":\"Name\"}"
+          },
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/51e47b84-1614-4bae-8413-3b12a35d5984/contacts/15d96bf0-0778-43dd-beb0-e5fcbed098e3"
+        },
+        "response": {
+          "bodySize": 64,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "{\"object\":\"contact\",\"id\":\"15d96bf0-0778-43dd-beb0-e5fcbed098e3\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41221961eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:58 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"40-Q/0oZD7kpL8/FoPah8p9wiyZ8mE\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "99"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:57.527Z",
+        "time": 263,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 263
+        }
+      },
+      {
+        "_id": "7adf5a3226f4e812b2574afe0e6ba8f9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 255,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.resend.com/audiences/51e47b84-1614-4bae-8413-3b12a35d5984/contacts/15d96bf0-0778-43dd-beb0-e5fcbed098e3"
+        },
+        "response": {
+          "bodySize": 221,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 221,
+            "text": "{\"object\":\"contact\",\"id\":\"15d96bf0-0778-43dd-beb0-e5fcbed098e3\",\"email\":\"test-update@example.com\",\"first_name\":\"Updated\",\"last_name\":\"Name\",\"created_at\":\"2025-11-30 20:42:46.04984+00\",\"unsubscribed\":false,\"properties\":{}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d4123cdf4eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:58 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"dd-L91hOY+yQbKHr0sVOOitwE7S8Qc\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "98"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:57.792Z",
+        "time": 182,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 182
+        }
+      },
+      {
+        "_id": "f8cf22e6f2df1ee72356eca1dc5ec33d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "authorization",
+              "value": "Bearer re_REDACTED_API_KEY"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "resend-node:6.5.2"
+            }
+          ],
+          "headersSize": 211,
+          "httpVersion": "HTTP/1.1",
+          "method": "DELETE",
+          "queryString": [],
+          "url": "https://api.resend.com/segments/51e47b84-1614-4bae-8413-3b12a35d5984"
+        },
+        "response": {
+          "bodySize": 79,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 79,
+            "text": "{\"object\":\"segment\",\"id\":\"51e47b84-1614-4bae-8413-3b12a35d5984\",\"deleted\":true}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "cf-ray",
+              "value": "9a6d41250a53eea7-MXP"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "content-encoding",
+              "value": "br"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "date",
+              "value": "Sun, 30 Nov 2025 20:56:58 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"4f-A8CgKokTSlpEJiaDSycO34tfxX4\""
+            },
+            {
+              "name": "ratelimit-limit",
+              "value": "100"
+            },
+            {
+              "name": "ratelimit-policy",
+              "value": "100;w=1"
+            },
+            {
+              "name": "ratelimit-remaining",
+              "value": "97"
+            },
+            {
+              "name": "ratelimit-reset",
+              "value": "1"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 372,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-11-30T20:56:57.976Z",
+        "time": 272,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 272
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/contacts/contacts.integration.spec.ts
+++ b/src/contacts/contacts.integration.spec.ts
@@ -16,108 +16,110 @@ describe('Contacts Integration Tests', () => {
     await polly.stop();
   });
 
-  describe('create', () => {
-    it('creates a contact', async () => {
-      const audienceResult = await resend.audiences.create({
-        name: 'Test audience for contact creation',
-      });
-
-      expect(audienceResult.data?.id).toBeTruthy();
-      const audienceId = audienceResult.data!.id;
-
-      try {
-        const result = await resend.contacts.create({
-          email: 'test@example.com',
-          audienceId,
-          firstName: 'Test',
-          lastName: 'User',
+  describe('contacts API endpoint', () => {
+    describe('create', () => {
+      it('creates a contact', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for contact creation 1',
         });
 
-        expect(result.data?.id).toBeTruthy();
-        expect(result.data?.object).toBe('contact');
-      } finally {
-        const removeResult = await resend.audiences.remove(audienceId);
-        expect(removeResult.data?.deleted).toBe(true);
-      }
-    });
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
 
-    it('handles validation errors', async () => {
-      // @ts-expect-error: Testing invalid input
-      const result = await resend.contacts.create({});
+        const topicResult = await resend.topics.create({
+          name: 'Test topic for contact creation 1',
+          defaultSubscription: 'opt_out',
+        });
 
-      expect(result.error?.name).toBe('missing_required_field');
-    });
-  });
+        expect(topicResult.data?.id).toBeTruthy();
+        const topicId = topicResult.data!.id;
 
-  describe('list', () => {
-    it('lists contacts without pagination', async () => {
-      const audienceResult = await resend.audiences.create({
-        name: 'Test audience for listing',
+        const contactPropertyResult = await resend.contactProperties.create({
+          key: 'test_property_for_contacts_api',
+          type: 'string',
+          fallbackValue: 'unknown',
+        });
+
+        expect(contactPropertyResult.data?.id).toBeTruthy();
+        const contactPropertyId = contactPropertyResult.data!.id;
+
+        try {
+          const result = await resend.contacts.create({
+            email: 'test@example.com',
+            segments: [{ id: segmentId }],
+            topics: [{ id: topicId, subscription: 'opt_in' }],
+            properties: {
+              test_property_for_contacts_api: 'updated value',
+            },
+            firstName: 'Test',
+            lastName: 'User',
+          });
+
+          expect(result.data?.id).toBeTruthy();
+          expect(result.data?.object).toBe('contact');
+        } finally {
+          const removeResult = await resend.segments.remove(segmentId);
+          expect(removeResult.data?.deleted).toBe(true);
+          const removeTopicResult = await resend.topics.remove(topicId);
+          expect(removeTopicResult.data?.deleted).toBe(true);
+          const removeContactPropertyResult =
+            await resend.contactProperties.remove(contactPropertyId);
+          expect(removeContactPropertyResult.data?.deleted).toBe(true);
+        }
       });
 
-      expect(audienceResult.data?.id).toBeTruthy();
-      const audienceId = audienceResult.data!.id;
+      it('handles validation errors', async () => {
+        // @ts-expect-error: Testing invalid input
+        const result = await resend.contacts.create({});
 
-      try {
+        expect(result.error?.name).toBe('missing_required_field');
+      });
+    });
+
+    describe('list', () => {
+      it('lists contacts without pagination', async () => {
         for (let i = 0; i < 6; i++) {
           await resend.contacts.create({
-            audienceId,
             email: `test.${i}@example.com`,
           });
         }
 
-        const result = await resend.contacts.list({ audienceId });
+        const result = await resend.contacts.list();
 
         expect(result.data?.object).toBe('list');
         expect(result.data?.data.length).toBe(6);
         expect(result.data?.has_more).toBe(false);
-      } finally {
-        const removeResult = await resend.audiences.remove(audienceId);
-        expect(removeResult.data?.deleted).toBe(true);
-      }
-    });
-
-    it('lists contacts with limit', async () => {
-      const audienceResult = await resend.audiences.create({
-        name: 'Test audience for listing with limit',
       });
 
-      expect(audienceResult.data?.id).toBeTruthy();
-      const audienceId = audienceResult.data!.id;
+      it('lists contacts with limit', async () => {
+        try {
+          for (let i = 0; i < 6; i++) {
+            await resend.contacts.create({
+              email: `test.${i}@example.com`,
+            });
+          }
 
-      try {
-        for (let i = 0; i < 6; i++) {
-          await resend.contacts.create({
-            audienceId,
-            email: `test.${i}@example.com`,
-          });
+          const result = await resend.contacts.list({ limit: 5 });
+
+          expect(result.data?.data.length).toBe(5);
+          expect(result.data?.has_more).toBe(true);
+        } finally {
+          await Promise.all(
+            Array.from({ length: 6 }).map((_, i) =>
+              resend.contacts.remove({
+                email: `test.${i}@example.com`,
+              }),
+            ),
+          );
         }
-
-        const result = await resend.contacts.list({ audienceId, limit: 5 });
-
-        expect(result.data?.data.length).toBe(5);
-        expect(result.data?.has_more).toBe(true);
-      } finally {
-        const removeResult = await resend.audiences.remove(audienceId);
-        expect(removeResult.data?.deleted).toBe(true);
-      }
-    });
-  });
-
-  describe('get', () => {
-    it('retrieves a contact by id', async () => {
-      const audienceResult = await resend.audiences.create({
-        name: 'Test audience for get by ID',
       });
+    }, 10000);
 
-      expect(audienceResult.data?.id).toBeTruthy();
-      const audienceId = audienceResult.data!.id;
-
-      try {
+    describe('get', () => {
+      it('retrieves a contact by id', async () => {
         const email = 'test-get-by-id@example.com';
         const createResult = await resend.contacts.create({
           email,
-          audienceId,
         });
 
         expect(createResult.data?.id).toBeTruthy();
@@ -125,202 +127,489 @@ describe('Contacts Integration Tests', () => {
 
         const getResult = await resend.contacts.get({
           id: contactId,
-          audienceId,
         });
 
         expect(getResult.data?.id).toBe(contactId);
         expect(getResult.data?.email).toBe(email);
         expect(getResult.data?.object).toBe('contact');
-      } finally {
-        const removeResult = await resend.audiences.remove(audienceId);
-        expect(removeResult.data?.deleted).toBe(true);
-      }
-    });
-
-    it('retrieves a contact by email', async () => {
-      const audienceResult = await resend.audiences.create({
-        name: 'Test audience for get by email',
       });
 
-      expect(audienceResult.data?.id).toBeTruthy();
-      const audienceId = audienceResult.data!.id;
-
-      try {
+      it('retrieves a contact by email', async () => {
         const email = 'test-get-by-email@example.com';
         const createResult = await resend.contacts.create({
           email,
-          audienceId,
         });
 
         expect(createResult.data?.id).toBeTruthy();
         const contactId = createResult.data!.id;
 
-        const getResult = await resend.contacts.get({ email, audienceId });
+        const getResult = await resend.contacts.get({ email });
 
         expect(getResult.data?.id).toBe(contactId);
         expect(getResult.data?.email).toBe(email);
         expect(getResult.data?.object).toBe('contact');
-      } finally {
-        const removeResult = await resend.audiences.remove(audienceId);
-        expect(removeResult.data?.deleted).toBe(true);
-      }
-    });
-
-    it('returns error for non-existent contact', async () => {
-      const audienceResult = await resend.audiences.create({
-        name: 'Test audience for non-existent contact',
       });
 
-      expect(audienceResult.data?.id).toBeTruthy();
-      const audienceId = audienceResult.data!.id;
-
-      try {
+      it('returns error for non-existent contact', async () => {
         const result = await resend.contacts.get({
           id: '00000000-0000-0000-0000-000000000000',
-          audienceId,
         });
 
         expect(result.error?.name).toBe('not_found');
-      } finally {
-        const removeResult = await resend.audiences.remove(audienceId);
-        expect(removeResult.data?.deleted).toBe(true);
-      }
+      });
+    });
+
+    describe('update', () => {
+      it('updates a contact', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for update 1',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const createResult = await resend.contacts.create({
+            email: 'test-update@example.com',
+            audienceId: segmentId,
+          });
+
+          expect(createResult.data?.id).toBeTruthy();
+          const contactId = createResult.data!.id;
+
+          const updateResult = await resend.contacts.update({
+            id: contactId,
+            audienceId: segmentId,
+            firstName: 'Updated',
+            lastName: 'Name',
+          });
+
+          expect(updateResult.data?.id).toBe(contactId);
+
+          const getResult = await resend.contacts.get({
+            id: contactId,
+            audienceId: segmentId,
+          });
+
+          expect(getResult.data?.first_name).toBe('Updated');
+          expect(getResult.data?.last_name).toBe('Name');
+        } finally {
+          const removeResult = await resend.segments.remove(segmentId);
+          expect(removeResult.data?.deleted).toBe(true);
+        }
+      });
+    });
+
+    describe('remove', () => {
+      it('removes a contact by id', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for remove by ID 1',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const createResult = await resend.contacts.create({
+            email: 'test-remove-by-id@example.com',
+            audienceId: segmentId,
+          });
+
+          expect(createResult.data?.id).toBeTruthy();
+          const contactId = createResult.data!.id;
+
+          const removeResult = await resend.contacts.remove({
+            id: contactId,
+            audienceId: segmentId,
+          });
+
+          expect(removeResult.data?.deleted).toBe(true);
+
+          const getResult = await resend.contacts.get({
+            id: contactId,
+            audienceId: segmentId,
+          });
+
+          expect(getResult.error?.name).toBe('not_found');
+        } finally {
+          const removeAudienceResult = await resend.segments.remove(segmentId);
+          expect(removeAudienceResult.data?.deleted).toBe(true);
+        }
+      });
+
+      it('removes a contact by email', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for remove by email 1',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const email = 'test-remove-by-email@example.com';
+          const createResult = await resend.contacts.create({
+            email,
+            audienceId: segmentId,
+          });
+
+          expect(createResult.data?.id).toBeDefined();
+
+          const removeResult = await resend.contacts.remove({
+            email,
+            audienceId: segmentId,
+          });
+
+          expect(removeResult.data?.deleted).toBe(true);
+
+          const getResult = await resend.contacts.get({
+            email,
+            audienceId: segmentId,
+          });
+
+          expect(getResult.error?.name).toBe('not_found');
+        } finally {
+          const removeAudienceResult = await resend.segments.remove(segmentId);
+          expect(removeAudienceResult.data?.deleted).toBe(true);
+        }
+      });
+
+      it('appears to remove a contact that never existed', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for non-existent delete 1',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const result = await resend.contacts.remove({
+            id: '00000000-0000-0000-0000-000000000000',
+            audienceId: segmentId,
+          });
+
+          expect(result.data?.deleted).toBe(true);
+        } finally {
+          const removeAudienceResult = await resend.segments.remove(segmentId);
+          expect(removeAudienceResult.data?.deleted).toBe(true);
+        }
+      });
     });
   });
 
-  describe('update', () => {
-    it('updates a contact', async () => {
-      const audienceResult = await resend.audiences.create({
-        name: 'Test audience for update',
+  describe('legacy contacts API endpoint', () => {
+    describe('create', () => {
+      it('creates a contact', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for contact creation 2',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const result = await resend.contacts.create({
+            email: 'test@example.com',
+            audienceId: segmentId,
+            firstName: 'Test',
+            lastName: 'User',
+          });
+
+          expect(result.data?.id).toBeTruthy();
+          expect(result.data?.object).toBe('contact');
+        } finally {
+          const removeResult = await resend.segments.remove(segmentId);
+          expect(removeResult.data?.deleted).toBe(true);
+        }
       });
 
-      expect(audienceResult.data?.id).toBeTruthy();
-      const audienceId = audienceResult.data!.id;
+      it('handles validation errors', async () => {
+        // @ts-expect-error: Testing invalid input
+        const result = await resend.contacts.create({});
 
-      try {
-        const createResult = await resend.contacts.create({
-          email: 'test-update@example.com',
-          audienceId,
-        });
-
-        expect(createResult.data?.id).toBeTruthy();
-        const contactId = createResult.data!.id;
-
-        const updateResult = await resend.contacts.update({
-          id: contactId,
-          audienceId,
-          firstName: 'Updated',
-          lastName: 'Name',
-        });
-
-        expect(updateResult.data?.id).toBe(contactId);
-
-        const getResult = await resend.contacts.get({
-          id: contactId,
-          audienceId,
-        });
-
-        expect(getResult.data?.first_name).toBe('Updated');
-        expect(getResult.data?.last_name).toBe('Name');
-      } finally {
-        const removeResult = await resend.audiences.remove(audienceId);
-        expect(removeResult.data?.deleted).toBe(true);
-      }
-    });
-  });
-
-  describe('remove', () => {
-    it('removes a contact by id', async () => {
-      const audienceResult = await resend.audiences.create({
-        name: 'Test audience for remove by ID',
+        expect(result.error?.name).toBe('missing_required_field');
       });
-
-      expect(audienceResult.data?.id).toBeTruthy();
-      const audienceId = audienceResult.data!.id;
-
-      try {
-        const createResult = await resend.contacts.create({
-          email: 'test-remove-by-id@example.com',
-          audienceId,
-        });
-
-        expect(createResult.data?.id).toBeTruthy();
-        const contactId = createResult.data!.id;
-
-        const removeResult = await resend.contacts.remove({
-          id: contactId,
-          audienceId,
-        });
-
-        expect(removeResult.data?.deleted).toBe(true);
-
-        const getResult = await resend.contacts.get({
-          id: contactId,
-          audienceId,
-        });
-
-        expect(getResult.error?.name).toBe('not_found');
-      } finally {
-        const removeAudienceResult = await resend.audiences.remove(audienceId);
-        expect(removeAudienceResult.data?.deleted).toBe(true);
-      }
     });
 
-    it('removes a contact by email', async () => {
-      const audienceResult = await resend.audiences.create({
-        name: 'Test audience for remove by email',
+    describe('list', () => {
+      it('lists contacts without pagination', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for listing 2',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          for (let i = 0; i < 6; i++) {
+            await resend.contacts.create({
+              audienceId: segmentId,
+              email: `test.${i}@example.com`,
+            });
+          }
+
+          const result = await resend.contacts.list({ segmentId });
+
+          expect(result.data?.object).toBe('list');
+          expect(result.data?.data.length).toBe(6);
+          expect(result.data?.has_more).toBe(false);
+        } finally {
+          const removeResult = await resend.segments.remove(segmentId);
+          expect(removeResult.data?.deleted).toBe(true);
+          await Promise.all(
+            Array.from({ length: 6 }).map((_, i) =>
+              resend.contacts.remove({
+                email: `test.${i}@example.com`,
+                audienceId: segmentId,
+              }),
+            ),
+          );
+        }
+      }, 10000);
+
+      it('lists contacts with limit', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for listing with limit 2',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          for (let i = 0; i < 6; i++) {
+            await resend.contacts.create({
+              audienceId: segmentId,
+              email: `test.${i}@example.com`,
+            });
+          }
+
+          const result = await resend.contacts.list({ segmentId, limit: 5 });
+
+          expect(result.data?.data.length).toBe(5);
+          expect(result.data?.has_more).toBe(true);
+        } finally {
+          const removeResult = await resend.segments.remove(segmentId);
+          expect(removeResult.data?.deleted).toBe(true);
+        }
       });
-
-      expect(audienceResult.data?.id).toBeTruthy();
-      const audienceId = audienceResult.data!.id;
-
-      try {
-        const email = 'test-remove-by-email@example.com';
-        const createResult = await resend.contacts.create({
-          email,
-          audienceId,
-        });
-
-        expect(createResult.data?.id).toBeDefined();
-
-        const removeResult = await resend.contacts.remove({
-          email,
-          audienceId,
-        });
-
-        expect(removeResult.data?.deleted).toBe(true);
-
-        const getResult = await resend.contacts.get({
-          email,
-          audienceId,
-        });
-
-        expect(getResult.error?.name).toBe('not_found');
-      } finally {
-        const removeAudienceResult = await resend.audiences.remove(audienceId);
-        expect(removeAudienceResult.data?.deleted).toBe(true);
-      }
     });
 
-    it('appears to remove a contact that never existed', async () => {
-      const audienceResult = await resend.audiences.create({
-        name: 'Test audience for non-existent delete',
-      });
-
-      expect(audienceResult.data?.id).toBeTruthy();
-      const audienceId = audienceResult.data!.id;
-
-      try {
-        const result = await resend.contacts.remove({
-          id: '00000000-0000-0000-0000-000000000000',
-          audienceId,
+    describe('get', () => {
+      it('retrieves a contact by id', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for get by ID 2',
         });
 
-        expect(result.data?.deleted).toBe(true);
-      } finally {
-        const removeAudienceResult = await resend.audiences.remove(audienceId);
-        expect(removeAudienceResult.data?.deleted).toBe(true);
-      }
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const email = 'test-get-by-id@example.com';
+          const createResult = await resend.contacts.create({
+            email,
+            audienceId: segmentId,
+          });
+
+          expect(createResult.data?.id).toBeTruthy();
+          const contactId = createResult.data!.id;
+
+          const getResult = await resend.contacts.get({
+            id: contactId,
+            audienceId: segmentId,
+          });
+
+          expect(getResult.data?.id).toBe(contactId);
+          expect(getResult.data?.email).toBe(email);
+          expect(getResult.data?.object).toBe('contact');
+        } finally {
+          const removeResult = await resend.segments.remove(segmentId);
+          expect(removeResult.data?.deleted).toBe(true);
+        }
+      });
+
+      it('retrieves a contact by email', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for get by ID 2',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+        try {
+          const email = 'test-get-by-email@example.com';
+          const createResult = await resend.contacts.create({
+            email,
+            audienceId: segmentId,
+          });
+
+          expect(createResult.data?.id).toBeTruthy();
+          const contactId = createResult.data!.id;
+
+          const getResult = await resend.contacts.get({ email });
+
+          expect(getResult.data?.id).toBe(contactId);
+          expect(getResult.data?.email).toBe(email);
+          expect(getResult.data?.object).toBe('contact');
+        } finally {
+          const removeResult = await resend.segments.remove(segmentId);
+          expect(removeResult.data?.deleted).toBe(true);
+        }
+      });
+
+      it('returns error for non-existent contact', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for get by ID 2',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const result = await resend.contacts.get({
+            id: '00000000-0000-0000-0000-000000000000',
+            audienceId: segmentId,
+          });
+
+          expect(result.error?.name).toBe('not_found');
+        } finally {
+          const removeResult = await resend.segments.remove(segmentId);
+          expect(removeResult.data?.deleted).toBe(true);
+        }
+      });
+    });
+
+    describe('update', () => {
+      it('updates a contact', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for update 2',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const createResult = await resend.contacts.create({
+            email: 'test-update@example.com',
+            audienceId: segmentId,
+          });
+
+          expect(createResult.data?.id).toBeTruthy();
+          const contactId = createResult.data!.id;
+
+          const updateResult = await resend.contacts.update({
+            id: contactId,
+            audienceId: segmentId,
+            firstName: 'Updated',
+            lastName: 'Name',
+          });
+
+          expect(updateResult.data?.id).toBe(contactId);
+
+          const getResult = await resend.contacts.get({
+            id: contactId,
+            audienceId: segmentId,
+          });
+
+          expect(getResult.data?.first_name).toBe('Updated');
+          expect(getResult.data?.last_name).toBe('Name');
+        } finally {
+          const removeResult = await resend.segments.remove(segmentId);
+          expect(removeResult.data?.deleted).toBe(true);
+        }
+      });
+    });
+
+    describe('remove', () => {
+      it('removes a contact by id', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for remove by ID 2',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const createResult = await resend.contacts.create({
+            email: 'test-remove-by-id@example.com',
+            audienceId: segmentId,
+          });
+
+          expect(createResult.data?.id).toBeTruthy();
+          const contactId = createResult.data!.id;
+
+          const removeResult = await resend.contacts.remove({
+            id: contactId,
+            audienceId: segmentId,
+          });
+
+          expect(removeResult.data?.deleted).toBe(true);
+
+          const getResult = await resend.contacts.get({
+            id: contactId,
+            audienceId: segmentId,
+          });
+
+          expect(getResult.error?.name).toBe('not_found');
+        } finally {
+          const removeAudienceResult = await resend.segments.remove(segmentId);
+          expect(removeAudienceResult.data?.deleted).toBe(true);
+        }
+      });
+
+      it('removes a contact by email', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for remove by email 2',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const email = 'test-remove-by-email@example.com';
+          const createResult = await resend.contacts.create({
+            email,
+            audienceId: segmentId,
+          });
+
+          expect(createResult.data?.id).toBeDefined();
+
+          const removeResult = await resend.contacts.remove({
+            email,
+            audienceId: segmentId,
+          });
+
+          expect(removeResult.data?.deleted).toBe(true);
+
+          const getResult = await resend.contacts.get({
+            email,
+            audienceId: segmentId,
+          });
+
+          expect(getResult.error?.name).toBe('not_found');
+        } finally {
+          const removeAudienceResult = await resend.segments.remove(segmentId);
+          expect(removeAudienceResult.data?.deleted).toBe(true);
+        }
+      });
+
+      it('appears to remove a contact that never existed', async () => {
+        const segmentResult = await resend.segments.create({
+          name: 'Test segment for non-existent delete 2',
+        });
+
+        expect(segmentResult.data?.id).toBeTruthy();
+        const segmentId = segmentResult.data!.id;
+
+        try {
+          const result = await resend.contacts.remove({
+            id: '00000000-0000-0000-0000-000000000000',
+            audienceId: segmentId,
+          });
+
+          expect(result.data?.deleted).toBe(true);
+        } finally {
+          const removeAudienceResult = await resend.segments.remove(segmentId);
+          expect(removeAudienceResult.data?.deleted).toBe(true);
+        }
+      });
     });
   });
 });

--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -5,6 +5,7 @@ import { mockSuccessResponse } from '../test-utils/mock-fetch';
 import type {
   CreateContactOptions,
   CreateContactResponseSuccess,
+  LegacyCreateContactOptions,
 } from './interfaces/create-contact-options.interface';
 import type {
   GetContactOptions,
@@ -28,78 +29,188 @@ describe('Contacts', () => {
   afterAll(() => fetchMocker.disableMocks());
 
   describe('create', () => {
-    it('creates a contact', async () => {
-      const payload: CreateContactOptions = {
-        email: 'team@resend.com',
-        properties: {
-          country: 'Canada',
-          edition: 1,
-        },
-      };
-      const response: CreateContactResponseSuccess = {
-        object: 'contact',
-        id: '3deaccfb-f47f-440a-8875-ea14b1716b43',
-      };
+    describe('current create contact endpoint', () => {
+      it('creates a contact', async () => {
+        const payload: CreateContactOptions = {
+          email: 'team@resend.com',
+          properties: {
+            country: 'Canada',
+            edition: 1,
+          },
+          segments: [{ id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223' }],
+          topics: [
+            {
+              id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87224',
+              subscription: 'opt_in',
+            },
+          ],
+        };
+        const response: CreateContactResponseSuccess = {
+          object: 'contact',
+          id: '3deaccfb-f47f-440a-8875-ea14b1716b43',
+        };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        await expect(
+          resend.contacts.create(payload),
+        ).resolves.toMatchInlineSnapshot(`
+          {
+            "data": {
+              "id": "3deaccfb-f47f-440a-8875-ea14b1716b43",
+              "object": "contact",
+            },
+            "error": null,
+            "headers": {
+              "content-type": "application/json",
+            },
+          }
+        `);
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
-      await expect(
-        resend.contacts.create(payload),
-      ).resolves.toMatchInlineSnapshot(`
-        {
-          "data": {
-            "id": "3deaccfb-f47f-440a-8875-ea14b1716b43",
-            "object": "contact",
+      it('throws error when missing name', async () => {
+        const payload: LegacyCreateContactOptions = {
+          email: '',
+          audienceId: '',
+        };
+        const response: ErrorResponse = {
+          name: 'missing_required_field',
+          message: 'Missing `email` field.',
+          statusCode: 422,
+        };
+
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 422,
+          headers: {
+            'content-type': 'application/json',
           },
-          "error": null,
-          "headers": {
-            "content-type": "application/json",
-          },
-        }
-      `);
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+        const result = resend.contacts.create(payload);
+
+        await expect(result).resolves.toMatchInlineSnapshot(`
+          {
+            "data": null,
+            "error": {
+              "message": "Missing \`email\` field.",
+              "name": "missing_required_field",
+              "statusCode": 422,
+            },
+            "headers": {
+              "content-type": "application/json",
+            },
+          }
+        `);
+      });
     });
 
-    it('throws error when missing name', async () => {
-      const payload: CreateContactOptions = {
-        email: '',
-        audienceId: '',
-      };
-      const response: ErrorResponse = {
-        name: 'missing_required_field',
-        message: 'Missing `email` field.',
-        statusCode: 422,
-      };
+    describe('legacy create contact endpoint', () => {
+      it('creates a contact', async () => {
+        const payload: LegacyCreateContactOptions = {
+          audienceId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
+          email: 'team@resend.com',
+          properties: {
+            country: 'Canada',
+            edition: 1,
+          },
+        };
+        const response: CreateContactResponseSuccess = {
+          object: 'contact',
+          id: '3deaccfb-f47f-440a-8875-ea14b1716b43',
+        };
 
-      fetchMock.mockOnce(JSON.stringify(response), {
-        status: 422,
-        headers: {
-          'content-type': 'application/json',
-        },
+        fetchMock.mockOnce(JSON.stringify(response), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        await expect(
+          resend.contacts.create(payload),
+        ).resolves.toMatchInlineSnapshot(`
+          {
+            "data": {
+              "id": "3deaccfb-f47f-440a-8875-ea14b1716b43",
+              "object": "contact",
+            },
+            "error": null,
+            "headers": {
+              "content-type": "application/json",
+            },
+          }
+        `);
       });
 
-      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
-
-      const result = resend.contacts.create(payload);
-
-      await expect(result).resolves.toMatchInlineSnapshot(`
-        {
-          "data": null,
-          "error": {
-            "message": "Missing \`email\` field.",
-            "name": "missing_required_field",
-            "statusCode": 422,
+      it('throws error when using `audienceId` together with `segments`', async () => {
+        const payload: LegacyCreateContactOptions = {
+          audienceId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
+          email: 'team@resend.com',
+          properties: {
+            country: 'Canada',
+            edition: 1,
           },
-          "headers": {
-            "content-type": "application/json",
+          //@ts-expect-error - `segments` is not a valid property for `LegacyCreateContactOptions`
+          segments: [{ id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223' }],
+        };
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        await expect(
+          resend.contacts.create(payload),
+        ).resolves.toMatchInlineSnapshot(`
+          {
+            "data": null,
+            "error": {
+              "message": "\`audienceId\` is deprecated, and cannot be used together with \`segments\` or \`topics\`. Use \`segments\` instead to add one or more segments to the new contact.",
+              "name": "invalid_parameter",
+              "statusCode": null,
+            },
+            "headers": null,
+          }
+        `);
+      });
+
+      it('throws error when using `audienceId` together with `topics`', async () => {
+        const payload: LegacyCreateContactOptions = {
+          audienceId: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87222',
+          email: 'team@resend.com',
+          properties: {
+            country: 'Canada',
+            edition: 1,
           },
-        }
-      `);
+          //@ts-expect-error - `topics` is not a valid property for `LegacyCreateContactOptions`
+          topics: [
+            {
+              id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87224',
+              subscription: 'opt_in',
+            },
+          ],
+        };
+
+        const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+        await expect(
+          resend.contacts.create(payload),
+        ).resolves.toMatchInlineSnapshot(`
+          {
+            "data": null,
+            "error": {
+              "message": "\`audienceId\` is deprecated, and cannot be used together with \`segments\` or \`topics\`. Use \`segments\` instead to add one or more segments to the new contact.",
+              "name": "invalid_parameter",
+              "statusCode": null,
+            },
+            "headers": null,
+          }
+        `);
+      });
     });
   });
 

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -5,6 +5,7 @@ import type {
   CreateContactRequestOptions,
   CreateContactResponse,
   CreateContactResponseSuccess,
+  LegacyCreateContactOptions,
 } from './interfaces/create-contact-options.interface';
 import type {
   GetContactOptions,
@@ -39,12 +40,26 @@ export class Contacts {
   }
 
   async create(
-    payload: CreateContactOptions,
+    payload: CreateContactOptions | LegacyCreateContactOptions,
     options: CreateContactRequestOptions = {},
   ): Promise<CreateContactResponse> {
-    if (!payload.audienceId) {
+    // Legacy create contact endpoint
+    if ('audienceId' in payload) {
+      if ('segments' in payload || 'topics' in payload) {
+        return {
+          data: null,
+          headers: null,
+          error: {
+            message:
+              '`audienceId` is deprecated, and cannot be used together with `segments` or `topics`. Use `segments` instead to add one or more segments to the new contact.',
+            statusCode: null,
+            name: 'invalid_parameter',
+          },
+        };
+      }
+
       const data = await this.resend.post<CreateContactResponseSuccess>(
-        '/contacts',
+        `/audiences/${payload.audienceId}/contacts`,
         {
           unsubscribed: payload.unsubscribed,
           email: payload.email,
@@ -57,14 +72,17 @@ export class Contacts {
       return data;
     }
 
+    // Current create contact endpoint
     const data = await this.resend.post<CreateContactResponseSuccess>(
-      `/audiences/${payload.audienceId}/contacts`,
+      '/contacts',
       {
         unsubscribed: payload.unsubscribed,
         email: payload.email,
         first_name: payload.firstName,
         last_name: payload.lastName,
         properties: payload.properties,
+        segments: payload.segments,
+        topics: payload.topics,
       },
       options,
     );

--- a/src/contacts/interfaces/create-contact-options.interface.ts
+++ b/src/contacts/interfaces/create-contact-options.interface.ts
@@ -6,13 +6,37 @@ interface CreateContactPropertiesOptions {
   [key: string]: string | number | null;
 }
 
-export interface CreateContactOptions {
-  audienceId?: string;
+export interface LegacyCreateContactOptions {
+  /**
+   * @deprecated Use `segments` instead to add one or more segments to the new contact
+   */
+  audienceId: string;
   email: string;
   unsubscribed?: boolean;
   firstName?: string;
   lastName?: string;
   properties?: CreateContactPropertiesOptions;
+  segments?: never;
+  topics?: never;
+}
+
+export interface CreateContactOptions {
+  email: string;
+  unsubscribed?: boolean;
+  firstName?: string;
+  lastName?: string;
+  properties?: CreateContactPropertiesOptions;
+  segments?: {
+    id: string;
+  }[];
+  topics?: {
+    id: string;
+    subscription: 'opt_in' | 'opt_out';
+  }[];
+  /**
+   * @deprecated Use `segments` instead to add one or more segments to the new contact
+   */
+  audienceId?: never;
 }
 
 export interface CreateContactRequestOptions extends PostOptions {}


### PR DESCRIPTION
With the new contacts API, contacts can be in multiple segments and topics. This PR allows creating a contact inside one or more segments (this replaces the use of `audience_id`) and also allows opting in or out of topics straight away.

Closes PRODUCT-1210


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support to create a contact in one or more segments and set topic opt-in/out at creation time. Deprecates audienceId in favor of segments, with guardrails to prevent mixing old and new payloads.

- **New Features**
  - contacts.create accepts segments: [{ id }] to assign multiple segments.
  - contacts.create accepts topics: [{ id, subscription: 'opt_in' | 'opt_out' }].
  - Clear validation error if audienceId is used together with segments or topics.
  - Keeps legacy support: audienceId still works when used alone.

- **Migration**
  - Replace audienceId with segments: pass one or more segment IDs.
  - Use topics to opt in or out during creation.
  - Do not mix audienceId with segments or topics; use one approach.

<sup>Written for commit 65b932dc68b00c8818d27ba691dcad9f3b9b3636. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



