### PR TITLE
chore: add react and react-dom as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "cross-env": "10.1.0",
     "dotenv": "17.2.3",
     "pkg-pr-new": "0.0.62",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
     "rimraf": "6.1.2",
     "tsdown": "0.20.1",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,12 @@ importers:
       pkg-pr-new:
         specifier: 0.0.62
         version: 0.0.62
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
       rimraf:
         specifier: 6.1.2
         version: 6.1.2
@@ -1288,8 +1294,17 @@ packages:
     peerDependencies:
       react: ^19.2.3
 
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
   requires-port@1.0.0:
@@ -2806,7 +2821,14 @@ snapshots:
       react: 19.2.3
       scheduler: 0.27.0
 
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
   react@19.2.3: {}
+
+  react@19.2.4: {}
 
   requires-port@1.0.0: {}
 


### PR DESCRIPTION
Closes #813

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add react and react-dom (19.2.4) as devDependencies to resolve peer dependency warnings and keep the local dev environment consistent. Updated pnpm-lock.yaml; closes #813.

<sup>Written for commit e63158c314db997c284acec442dff522d66027bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

