### PR TITLE
fix: inbound attachment types mismatch API values

### DIFF
--- a/src/emails/receiving/interfaces/get-receiving-email.interface.ts
+++ b/src/emails/receiving/interfaces/get-receiving-email.interface.ts
@@ -20,11 +20,11 @@ export interface GetReceivingEmailResponseSuccess {
   } | null;
   attachments: Array<{
     id: string;
-    filename: string;
+    filename: string | null;
     size: number;
     content_type: string;
-    content_id: string;
-    content_disposition: string;
+    content_id: string | null;
+    content_disposition: string | null;
   }>;
 }
 

--- a/src/webhooks/interfaces/webhook-event.interface.ts
+++ b/src/webhooks/interfaces/webhook-event.interface.ts
@@ -52,10 +52,10 @@ interface EmailSuppressed {
 
 interface ReceivedEmailAttachment {
   id: string;
-  filename: string;
+  filename: string | null;
   content_type: string;
-  content_disposition: string;
-  content_id?: string;
+  content_disposition: string | null;
+  content_id: string | null;
 }
 
 interface ReceivedEmailEventData {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align inbound attachment types with the API by allowing null for filename, content_id, and content_disposition. This removes type mismatches in receiving email and webhook payloads.

- **Bug Fixes**
  - GetReceivingEmailResponseSuccess.attachments: filename, content_id, and content_disposition are now string | null.
  - ReceivedEmailAttachment: filename and content_disposition are nullable; content_id is string | null (no longer optional).
  - Prevents type errors and parsing issues when the API returns null values.

<sup>Written for commit bbff122ff95fb684d1e6da3d9ecf1a0074c39228. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

