### PR TITLE
fix: export email list response type

### DIFF
--- a/src/emails/interfaces/index.ts
+++ b/src/emails/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './cancel-email-options.interface';
 export * from './create-email-options.interface';
 export * from './get-email-options.interface';
+export * from './list-emails-options.interface';
 export * from './update-email-options.interface';


### PR DESCRIPTION
- Exports the email list response interface from the public barrel so consumers can type `emails.list` responses.
- consistent with other list endpoints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported the list-emails options interface from the public emails barrel so consumers can type emails.list calls. This fixes the missing export and keeps consistency with other list endpoints.

<sup>Written for commit f33d8121cbc8b1b513d3e7f5a3c04ac85f12bc76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

