### PR TITLE
fix: export email list response type

### DIFF
--- a/src/emails/interfaces/index.ts
+++ b/src/emails/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './cancel-email-options.interface';
 export * from './create-email-options.interface';
 export * from './get-email-options.interface';
+export * from './list-emails-options.interface';
 export * from './update-email-options.interface';


### PR DESCRIPTION
- Exports the email list response interface from the public barrel so consumers can type `emails.list` responses.
- consistent with other list endpoints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported the list-emails options interface from the public barrel so consumers can import types for emails.list. Fixes the missing export and keeps it consistent with other list endpoints.

<sup>Written for commit 25ff5e3dc871cc29f75403088069f8d5d5037616. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

