### PR TITLE
fix: prevent payload mutation and parallelize batch rendering

### DIFF
--- a/src/batch/batch.ts
+++ b/src/batch/batch.ts
@@ -1,4 +1,3 @@
-import type { EmailApiOptions } from '../common/interfaces/email-api-options.interface';
 import { parseEmailToApiOptions } from '../common/utils/parse-email-to-api-options';
 import { render } from '../render';
 import type { Resend } from '../resend';
@@ -23,16 +22,15 @@ export class Batch {
     payload: CreateBatchOptions,
     options?: Options,
   ): Promise<CreateBatchResponse<Options>> {
-    const emails: EmailApiOptions[] = [];
-
-    for (const email of payload) {
-      if (email.react) {
-        email.html = await render(email.react);
-        email.react = undefined;
-      }
-
-      emails.push(parseEmailToApiOptions(email));
-    }
+    const emails = await Promise.all(
+      payload.map(async (email) => {
+        if (email.react) {
+          const html = await render(email.react);
+          return parseEmailToApiOptions({ ...email, html });
+        }
+        return parseEmailToApiOptions(email);
+      }),
+    );
 
     const data = await this.resend.post<CreateBatchSuccessResponse<Options>>(
       '/emails/batch',

--- a/src/emails/emails.ts
+++ b/src/emails/emails.ts
@@ -50,13 +50,13 @@ export class Emails {
     payload: CreateEmailOptions,
     options: CreateEmailRequestOptions = {},
   ): Promise<CreateEmailResponse> {
-    if (payload.react) {
-      payload.html = await render(payload.react as React.ReactElement);
-    }
+    const resolved = payload.react
+      ? { ...payload, html: await render(payload.react as React.ReactElement) }
+      : payload;
 
     const data = await this.resend.post<CreateEmailResponseSuccess>(
       '/emails',
-      parseEmailToApiOptions(payload),
+      parseEmailToApiOptions(resolved),
       options,
     );
 

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -51,6 +51,7 @@ export class Templates {
   private async performCreate(
     payload: CreateTemplateOptions,
   ): Promise<CreateTemplateResponse> {
+    let resolved = payload;
     if (payload.react) {
       if (!this.renderAsync) {
         try {
@@ -63,14 +64,16 @@ export class Templates {
         }
       }
 
-      payload.html = await this.renderAsync(
-        payload.react as React.ReactElement,
-      );
+      const renderFn = this.renderAsync;
+      resolved = {
+        ...payload,
+        html: await renderFn(payload.react as React.ReactElement),
+      };
     }
 
     return this.resend.post<CreateTemplateResponseSuccess>(
       '/templates',
-      parseTemplateToApiOptions(payload),
+      parseTemplateToApiOptions(resolved),
     );
   }
 


### PR DESCRIPTION
- **Fix payload mutation** in `emails.create()`, `templates.create()`, and
  `batch.create()` — these methods currently modify the caller's input object
  (`payload.html = ...`, `email.react = undefined`), which can cause bugs when reusing the
  same options object across multiple calls
 - **Parallelize batch rendering** — replace sequential `for...of` + `await` with
  `Promise.all`, so React template rendering for batch emails runs concurrently instead of
  one-by-one

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents payload mutation across email/template/batch APIs and runs batch React rendering in parallel to speed up sends. Removes side effects when reusing options objects and lowers batch latency.

- **Bug Fixes**
  - Stop mutating caller input (payload.html, email.react) in emails.create(), templates.create(), and batch.create(); use immutable copies.

- **Performance**
  - Parallelize batch React rendering in batch.create() with Promise.all instead of sequential awaits.

<sup>Written for commit 24647f5d24593776407cf49cacba874a12c48126. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

