### PR TITLE
fix: typo and align remove-contact response with API

### DIFF
--- a/src/contacts/contacts.spec.ts
+++ b/src/contacts/contacts.spec.ts
@@ -876,11 +876,12 @@ describe('Contacts', () => {
   describe('remove', () => {
     it('removes a contact by id', async () => {
       const response: RemoveContactsResponseSuccess = {
-        contact: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
         object: 'contact',
         deleted: true,
+        contact: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
       };
-      fetchMock.mockOnce(JSON.stringify(response), {
+      fetchMock.mockOnce(JSON.stringify({ ...response, contact: undefined }), {
         status: 200,
         headers: {
           'content-type': 'application/json',
@@ -899,6 +900,7 @@ describe('Contacts', () => {
           "data": {
             "contact": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
             "deleted": true,
+            "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
             "object": "contact",
           },
           "error": null,
@@ -911,11 +913,12 @@ describe('Contacts', () => {
 
     it('removes a contact by email', async () => {
       const response: RemoveContactsResponseSuccess = {
-        contact: 'acme@example.com',
+        id: 'acme@example.com',
         object: 'contact',
         deleted: true,
+        contact: 'acme@example.com',
       };
-      fetchMock.mockOnce(JSON.stringify(response), {
+      fetchMock.mockOnce(JSON.stringify({ ...response, contact: undefined }), {
         status: 200,
         headers: {
           'content-type': 'application/json',
@@ -934,6 +937,7 @@ describe('Contacts', () => {
           "data": {
             "contact": "acme@example.com",
             "deleted": true,
+            "id": "acme@example.com",
             "object": "contact",
           },
           "error": null,
@@ -946,11 +950,12 @@ describe('Contacts', () => {
 
     it('removes a contact by string id', async () => {
       const response: RemoveContactsResponseSuccess = {
-        contact: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
+        id: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
         object: 'contact',
         deleted: true,
+        contact: '3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223',
       };
-      fetchMock.mockOnce(JSON.stringify(response), {
+      fetchMock.mockOnce(JSON.stringify({ ...response, contact: undefined }), {
         status: 200,
         headers: {
           'content-type': 'application/json',
@@ -965,6 +970,7 @@ describe('Contacts', () => {
           "data": {
             "contact": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
             "deleted": true,
+            "id": "3d4a472d-bc6d-4dd2-aa9d-d3d50ce87223",
             "object": "contact",
           },
           "error": null,

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -30,6 +30,18 @@ import type {
 import { ContactSegments } from './segments/contact-segments';
 import { ContactTopics } from './topics/contact-topics';
 
+function normalizeRemoveResponse(
+  response: RemoveContactsResponse,
+): RemoveContactsResponse {
+  if (response.data && 'id' in response.data) {
+    return {
+      ...response,
+      data: { ...response.data, contact: response.data.id },
+    };
+  }
+  return response;
+}
+
 export class Contacts {
   readonly topics: ContactTopics;
   readonly segments: ContactSegments;
@@ -40,11 +52,11 @@ export class Contacts {
   }
 
   async create(
-    paylaod: CreateContactOptions,
+    payload: CreateContactOptions,
     options?: CreateContactRequestOptions,
   ): Promise<CreateContactResponse>;
   async create(
-    paylaod: LegacyCreateContactOptions,
+    payload: LegacyCreateContactOptions,
     options?: CreateContactRequestOptions,
   ): Promise<CreateContactResponse>;
 
@@ -183,8 +195,10 @@ export class Contacts {
 
   async remove(payload: RemoveContactOptions): Promise<RemoveContactsResponse> {
     if (typeof payload === 'string') {
-      return this.resend.delete<RemoveContactsResponseSuccess>(
-        `/contacts/${payload}`,
+      return normalizeRemoveResponse(
+        await this.resend.delete<RemoveContactsResponseSuccess>(
+          `/contacts/${payload}`,
+        ),
       );
     }
 
@@ -201,15 +215,19 @@ export class Contacts {
     }
 
     if (!payload.audienceId) {
-      return this.resend.delete<RemoveContactsResponseSuccess>(
-        `/contacts/${payload?.email ? payload?.email : payload?.id}`,
+      return normalizeRemoveResponse(
+        await this.resend.delete<RemoveContactsResponseSuccess>(
+          `/contacts/${payload?.email ? payload?.email : payload?.id}`,
+        ),
       );
     }
 
-    return this.resend.delete<RemoveContactsResponseSuccess>(
-      `/audiences/${payload.audienceId}/contacts/${
-        payload?.email ? payload?.email : payload?.id
-      }`,
+    return normalizeRemoveResponse(
+      await this.resend.delete<RemoveContactsResponseSuccess>(
+        `/audiences/${payload.audienceId}/contacts/${
+          payload?.email ? payload?.email : payload?.id
+        }`,
+      ),
     );
   }
 }

--- a/src/contacts/interfaces/remove-contact.interface.ts
+++ b/src/contacts/interfaces/remove-contact.interface.ts
@@ -4,6 +4,11 @@ import type { SelectingField } from './contact';
 export type RemoveContactsResponseSuccess = {
   object: 'contact';
   deleted: boolean;
+  id: string;
+  /**
+   * Same as `id`. Kept for backward compatibility.
+   * @deprecated Use `id` instead. Will be removed in the next major version.
+   */
   contact: string;
 };
 

--- a/src/topics/topics.spec.ts
+++ b/src/topics/topics.spec.ts
@@ -127,14 +127,14 @@ describe('Topics', () => {
             id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
             name: 'Newsletter',
             description: 'Weekly newsletter updates',
-            defaultSubscription: 'opt_in',
+            default_subscription: 'opt_in',
             created_at: '2023-04-07T23:13:52.669661+00:00',
           },
           {
             id: 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
             name: 'Product Updates',
             description: 'Product announcements and updates',
-            defaultSubscription: 'opt_out',
+            default_subscription: 'opt_out',
             created_at: '2023-04-07T23:13:20.417116+00:00',
           },
         ],
@@ -149,14 +149,14 @@ describe('Topics', () => {
             "data": [
               {
                 "created_at": "2023-04-07T23:13:52.669661+00:00",
-                "defaultSubscription": "opt_in",
+                "default_subscription": "opt_in",
                 "description": "Weekly newsletter updates",
                 "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
                 "name": "Newsletter",
               },
               {
                 "created_at": "2023-04-07T23:13:20.417116+00:00",
-                "defaultSubscription": "opt_out",
+                "default_subscription": "opt_out",
                 "description": "Product announcements and updates",
                 "id": "ac7503ac-e027-4aea-94b3-b0acd46f65f9",
                 "name": "Product Updates",
@@ -212,7 +212,7 @@ describe('Topics', () => {
         id: 'fd61172c-cafc-40f5-b049-b45947779a29',
         name: 'Newsletter',
         description: 'Weekly newsletter updates',
-        defaultSubscription: 'opt_in',
+        default_subscription: 'opt_in',
         created_at: '2024-01-16T18:12:26.514Z',
       };
 
@@ -225,7 +225,7 @@ describe('Topics', () => {
         {
           "data": {
             "created_at": "2024-01-16T18:12:26.514Z",
-            "defaultSubscription": "opt_in",
+            "default_subscription": "opt_in",
             "description": "Weekly newsletter updates",
             "id": "fd61172c-cafc-40f5-b049-b45947779a29",
             "name": "Newsletter",


### PR DESCRIPTION
- contacts.create(): fix parameter name typo.
- contacts.remove() response: added `id` to match API; keep `contact` as deprecated alias. we can start using `id` in the new code and `contact` we can remove in the next major.

reference: https://github.com/resend/resend-openapi/blob/main/resend.yaml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns remove-contact response with the API by returning id and keeping contact as a deprecated alias for backward compatibility. Also fixes a parameter typo in contacts.create and updates topics tests to match API field names.

- **Bug Fixes**
  - contacts.remove(): return id; keep contact as a deprecated alias; normalize responses for back-compat.
  - contacts.create(): fix payload parameter name typo.
  - Tests updated to expect default_subscription (snake_case) in topics.

- **Migration**
  - Read id from remove-contact responses. contact is deprecated and will be removed in the next major.

<sup>Written for commit d818babf7f14b5ee4affeabd020a106baae306f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

