### PR TITLE
refactor: resend client options

### DIFF
--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -256,7 +256,7 @@ describe('Broadcasts', () => {
       `);
     });
 
-    it('returns an error when fetch fails', async () => {
+    it('returns an error when fetch fails (with env base URL)', async () => {
       const originalEnv = process.env;
       process.env = {
         ...originalEnv,
@@ -281,6 +281,31 @@ describe('Broadcasts', () => {
         }),
       );
       process.env = originalEnv;
+    });
+
+    it('returns an error when fetch fails (with client options)', async () => {
+      const resendWithInvalidBase = new Resend(
+        're_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        { baseUrl: 'http://invalidurl.noturl' },
+      );
+
+      const result = await resendWithInvalidBase.broadcasts.create({
+        from: 'example@resend.com',
+        segmentId: '0192f4f1-d5f9-7110-8eb5-370552515917',
+        subject: 'Hello World',
+        text: 'Hello world',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          data: null,
+          error: {
+            message: 'Unable to fetch data. The request could not be resolved.',
+            name: 'application_error',
+            statusCode: null,
+          },
+        }),
+      );
     });
 
     it('returns an error when api responds with text payload', async () => {

--- a/src/broadcasts/broadcasts.spec.ts
+++ b/src/broadcasts/broadcasts.spec.ts
@@ -306,6 +306,13 @@ describe('Broadcasts', () => {
           },
         }),
       );
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://invalidurl.noturl/broadcasts',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.any(Headers),
+        }),
+      );
     });
 
     it('returns an error when api responds with text payload', async () => {

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -417,6 +417,9 @@ describe('Emails', () => {
           },
         }),
       );
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'http://invalidurl.noturl/emails',
+      );
     });
 
     it('returns an error when api responds with text payload', async () => {

--- a/src/emails/emails.spec.ts
+++ b/src/emails/emails.spec.ts
@@ -367,7 +367,7 @@ describe('Emails', () => {
       `);
     });
 
-    it('returns an error when fetch fails', async () => {
+    it('returns an error when fetch fails (with env base URL)', async () => {
       const originalEnv = process.env;
       process.env = {
         ...originalEnv,
@@ -392,6 +392,31 @@ describe('Emails', () => {
         }),
       );
       process.env = originalEnv;
+    });
+
+    it('returns an error when fetch fails (with client options)', async () => {
+      const resendWithInvalidBase = new Resend(
+        're_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop',
+        { baseUrl: 'http://invalidurl.noturl' },
+      );
+
+      const result = await resendWithInvalidBase.emails.send({
+        from: 'example@resend.com',
+        to: 'bu@resend.com',
+        subject: 'Hello World',
+        text: 'Hello world',
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          data: null,
+          error: {
+            message: 'Unable to fetch data. The request could not be resolved.',
+            name: 'application_error',
+            statusCode: null,
+          },
+        }),
+      );
     });
 
     it('returns an error when api responds with text payload', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export * from './emails/attachments/interfaces';
 export * from './emails/interfaces';
 export * from './emails/receiving/interfaces';
 export type { ErrorResponse, Response } from './interfaces';
-export { Resend } from './resend';
+export { Resend, type ResendClientOptions } from './resend';
 export * from './segments/interfaces';
 export * from './templates/interfaces';
 export * from './topics/interfaces';

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -63,9 +63,9 @@ export class Resend {
     this._key = apiKey;
 
     this.baseUrl =
-      options?.baseUrl ?? getEnv('RESEND_BASE_URL') ?? defaultBaseUrl;
+      options?.baseUrl || getEnv('RESEND_BASE_URL') || defaultBaseUrl;
     const userAgent =
-      options?.userAgent ?? getEnv('RESEND_USER_AGENT') ?? defaultUserAgent;
+      options?.userAgent || getEnv('RESEND_USER_AGENT') || defaultUserAgent;
     this.fetchImpl = options?.fetch ?? fetch;
 
     this.headers = new Headers({

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -18,11 +18,11 @@ import { Webhooks } from './webhooks/webhooks';
 const defaultBaseUrl = 'https://api.resend.com';
 const defaultUserAgent = `resend-node:${version}`;
 
-/** optional overrides when creating the client instead of env variables */
+/** optional options when creating the client instead of env variables */
 export type ResendClientOptions = {
   baseUrl?: string;
   userAgent?: string;
-  /** custom fetch used for tests. */
+  /** custom fetch can be used for tests. */
   fetch?: typeof fetch;
 };
 

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -17,17 +17,25 @@ import { Webhooks } from './webhooks/webhooks';
 
 const defaultBaseUrl = 'https://api.resend.com';
 const defaultUserAgent = `resend-node:${version}`;
-const baseUrl =
-  typeof process !== 'undefined' && process.env
-    ? process.env.RESEND_BASE_URL || defaultBaseUrl
-    : defaultBaseUrl;
-const userAgent =
-  typeof process !== 'undefined' && process.env
-    ? process.env.RESEND_USER_AGENT || defaultUserAgent
-    : defaultUserAgent;
+
+/** optional overrides when creating the client instead of env variables */
+export type ResendClientOptions = {
+  baseUrl?: string;
+  userAgent?: string;
+  /** custom fetch used for tests. */
+  fetch?: typeof fetch;
+};
+
+function getEnv(name: string): string | undefined {
+  if (typeof process === 'undefined' || !process.env) return undefined;
+  return process.env[name];
+}
 
 export class Resend {
   private readonly headers: Headers;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly _key: string;
 
   readonly apiKeys = new ApiKeys(this);
   readonly segments = new Segments(this);
@@ -45,29 +53,35 @@ export class Resend {
   readonly templates = new Templates(this);
   readonly topics = new Topics(this);
 
-  constructor(readonly key?: string) {
-    if (!key) {
-      if (typeof process !== 'undefined' && process.env) {
-        this.key = process.env.RESEND_API_KEY;
-      }
-
-      if (!this.key) {
-        throw new Error(
-          'Missing API key. Pass it to the constructor `new Resend("re_123")`',
-        );
-      }
+  constructor(key?: string, options?: ResendClientOptions) {
+    const apiKey = key ?? getEnv('RESEND_API_KEY');
+    if (!apiKey) {
+      throw new Error(
+        'Missing API key. Pass it to the constructor `new Resend("re_123")` or set RESEND_API_KEY.',
+      );
     }
+    this._key = apiKey;
+
+    this.baseUrl =
+      options?.baseUrl ?? getEnv('RESEND_BASE_URL') ?? defaultBaseUrl;
+    const userAgent =
+      options?.userAgent ?? getEnv('RESEND_USER_AGENT') ?? defaultUserAgent;
+    this.fetchImpl = options?.fetch ?? fetch;
 
     this.headers = new Headers({
-      Authorization: `Bearer ${this.key}`,
+      Authorization: `Bearer ${apiKey}`,
       'User-Agent': userAgent,
       'Content-Type': 'application/json',
     });
   }
 
+  get key(): string {
+    return this._key;
+  }
+
   async fetchRequest<T>(path: string, options = {}): Promise<Response<T>> {
     try {
-      const response = await fetch(`${baseUrl}${path}`, options);
+      const response = await this.fetchImpl(`${this.baseUrl}${path}`, options);
 
       if (!response.ok) {
         try {

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -63,9 +63,9 @@ export class Resend {
     this._key = apiKey;
 
     this.baseUrl =
-      options?.baseUrl || getEnv('RESEND_BASE_URL') || defaultBaseUrl;
+      options?.baseUrl ?? (getEnv('RESEND_BASE_URL') || defaultBaseUrl);
     const userAgent =
-      options?.userAgent || getEnv('RESEND_USER_AGENT') || defaultUserAgent;
+      options?.userAgent ?? (getEnv('RESEND_USER_AGENT') || defaultUserAgent);
     this.fetchImpl = options?.fetch ?? fetch;
 
     this.headers = new Headers({


### PR DESCRIPTION
- updated the resend constructor to accept optional client options for base URL, user agent and custom fetch.
- added a new type -> ResendClientOptions.
- updated tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for per-client options in the Resend constructor (baseUrl, userAgent, custom fetch) to improve configurability and testing. Options override env vars and allow explicit empty strings; the API key error is clearer.

- **New Features**
  - ResendClientOptions type exported; constructor now accepts key and options.
  - fetchRequest uses instance baseUrl and custom fetch.
  - Tests cover env vs client-option base URL failures for emails and broadcasts, with URL assertions.

<sup>Written for commit d3d6ccf7097af3f6d2093e28bb4b389c7fcf7162. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

