### PR TITLE
chore(ci): migrate from BuildJet to Blacksmith runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   e2e:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   lint:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   pin-dependencies-check:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   pr-title-check:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -12,7 +12,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   tests:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
       image: node:24-slim
       # credentials:


### PR DESCRIPTION
## Summary

- Replaces all BuildJet runner labels with their Blacksmith equivalents across 6 CI workflows
  - `buildjet-4vcpu-ubuntu-2204` → `blacksmith-4vcpu-ubuntu-2204` (e2e, tests, preview-release)
  - `buildjet-2vcpu-ubuntu-2204` → `blacksmith-2vcpu-ubuntu-2204` (lint, pr-title-check, pin-dependencies-check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch all GitHub Actions workflows from BuildJet to Blacksmith runners to keep CI consistent and reliable.
Replaced runner labels across six workflows: buildjet-4vcpu-ubuntu-2204 → blacksmith-4vcpu-ubuntu-2204 (e2e, tests, preview-release) and buildjet-2vcpu-ubuntu-2204 → blacksmith-2vcpu-ubuntu-2204 (lint, pr-title-check, pin-dependencies-check).

<sup>Written for commit 9a7801cbd18917296c0981080b52311313f80cb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

