### PR TITLE
feat: update code to correspond to automation API changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.10.0-preview-workflows.4",
+  "version": "6.10.0-preview-workflows.5",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/automations/interfaces/automation-step.interface.ts
+++ b/src/automations/interfaces/automation-step.interface.ts
@@ -40,7 +40,7 @@ export interface TriggerStepConfig {
 }
 
 export interface DelayStepConfig {
-  seconds: number;
+  duration: string;
 }
 
 export interface SendEmailStepConfig {
@@ -53,7 +53,7 @@ export interface SendEmailStepConfig {
 
 export interface WaitForEventStepConfig {
   eventName: string;
-  timeoutSeconds?: number;
+  timeout?: string;
   filterRule?: ConditionRule;
 }
 

--- a/src/common/utils/parse-automation-to-api-options.spec.ts
+++ b/src/common/utils/parse-automation-to-api-options.spec.ts
@@ -12,17 +12,17 @@ describe('parseAutomationToApiOptions', () => {
       status: 'enabled',
       steps: [
         {
-          ref: 'trigger_1',
+          key: 'trigger_1',
           type: 'trigger',
           config: { eventName: 'user.signed_up' },
         },
         {
-          ref: 'delay_1',
+          key: 'delay_1',
           type: 'delay',
-          config: { seconds: 3600 },
+          config: { duration: '1 hour' },
         },
         {
-          ref: 'send_1',
+          key: 'send_1',
           type: 'send_email',
           config: {
             templateId: 'tmpl_123',
@@ -33,11 +33,11 @@ describe('parseAutomationToApiOptions', () => {
           },
         },
         {
-          ref: 'wait_1',
+          key: 'wait_1',
           type: 'wait_for_event',
           config: {
             eventName: 'user.confirmed',
-            timeoutSeconds: 86400,
+            timeout: '1 day',
             filterRule: {
               type: 'rule',
               field: 'status',
@@ -47,7 +47,7 @@ describe('parseAutomationToApiOptions', () => {
           },
         },
         {
-          ref: 'cond_1',
+          key: 'cond_1',
           type: 'condition',
           config: {
             type: 'rule',
@@ -72,17 +72,17 @@ describe('parseAutomationToApiOptions', () => {
       status: 'enabled',
       steps: [
         {
-          ref: 'trigger_1',
+          key: 'trigger_1',
           type: 'trigger',
           config: { event_name: 'user.signed_up' },
         },
         {
-          ref: 'delay_1',
+          key: 'delay_1',
           type: 'delay',
-          config: { seconds: 3600 },
+          config: { duration: '1 hour' },
         },
         {
-          ref: 'send_1',
+          key: 'send_1',
           type: 'send_email',
           config: {
             template_id: 'tmpl_123',
@@ -93,11 +93,11 @@ describe('parseAutomationToApiOptions', () => {
           },
         },
         {
-          ref: 'wait_1',
+          key: 'wait_1',
           type: 'wait_for_event',
           config: {
             event_name: 'user.confirmed',
-            timeout_seconds: 86400,
+            timeout: '1 day',
             filter_rule: {
               type: 'rule',
               field: 'status',
@@ -107,7 +107,7 @@ describe('parseAutomationToApiOptions', () => {
           },
         },
         {
-          ref: 'cond_1',
+          key: 'cond_1',
           type: 'condition',
           config: {
             type: 'rule',
@@ -131,7 +131,7 @@ describe('parseAutomationToApiOptions', () => {
       name: 'Edge Test',
       steps: [
         {
-          ref: 'trigger_1',
+          key: 'trigger_1',
           type: 'trigger',
           config: { eventName: 'test.event' },
         },
@@ -157,7 +157,7 @@ describe('parseAutomationToApiOptions', () => {
       name: 'Minimal Automation',
       steps: [
         {
-          ref: 'trigger_1',
+          key: 'trigger_1',
           type: 'trigger',
           config: { eventName: 'test.event' },
         },
@@ -172,7 +172,7 @@ describe('parseAutomationToApiOptions', () => {
       status: undefined,
       steps: [
         {
-          ref: 'trigger_1',
+          key: 'trigger_1',
           type: 'trigger',
           config: { event_name: 'test.event' },
         },

--- a/src/common/utils/parse-automation-to-api-options.ts
+++ b/src/common/utils/parse-automation-to-api-options.ts
@@ -7,7 +7,7 @@ import type { CreateAutomationOptions } from '../../automations/interfaces/creat
 import type { SendEventOptions } from '../../events/interfaces/send-event.interface';
 
 interface AutomationStepApiOptions {
-  ref: string;
+  key: string;
   type: string;
   config: unknown;
 }
@@ -36,15 +36,15 @@ function parseStepConfig(step: AutomationStep): AutomationStepApiOptions {
   switch (step.type) {
     case 'trigger':
       return {
-        ref: step.ref,
+        key: step.key,
         type: step.type,
         config: { event_name: step.config.eventName },
       };
     case 'delay':
-      return { ref: step.ref, type: step.type, config: step.config };
+      return { key: step.key, type: step.type, config: step.config };
     case 'send_email':
       return {
-        ref: step.ref,
+        key: step.key,
         type: step.type,
         config: {
           template_id: step.config.templateId,
@@ -56,16 +56,16 @@ function parseStepConfig(step: AutomationStep): AutomationStepApiOptions {
       };
     case 'wait_for_event':
       return {
-        ref: step.ref,
+        key: step.key,
         type: step.type,
         config: {
           event_name: step.config.eventName,
-          timeout_seconds: step.config.timeoutSeconds,
+          timeout: step.config.timeout,
           filter_rule: step.config.filterRule,
         },
       };
     case 'condition':
-      return { ref: step.ref, type: step.type, config: step.config };
+      return { key: step.key, type: step.type, config: step.config };
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates automations to use natural‑language durations and align field names with the new Automation API. Implements `duration` and `timeout` strings and switches step identifiers from `ref` to `key` (PRODUCT-1906).

- **New Features**
  - Delay and wait_for_event now accept strings like "1 hour" and "1 day".

- **Migration**
  - Replace `seconds` with `duration: string` in delay steps.
  - Replace `timeoutSeconds` with `timeout: string` in wait_for_event.
  - Replace `ref` with `key` for step identifiers (interfaces and API parsing).

<sup>Written for commit e5a534ee372f758ee660a7349ade8b5c904d7c2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

