### PR TITLE
chore: automations breaking changes

### DIFF
--- a/src/automation-runs/automation-runs.spec.ts
+++ b/src/automation-runs/automation-runs.spec.ts
@@ -29,13 +29,21 @@ describe('get', () => {
       object: 'automation_run',
       id: 'wr_456',
       status: 'completed',
-      trigger: {
-        event_name: 'user.created',
-        payload: { email: 'jane@example.com' },
-      },
       started_at: '2024-01-01T00:00:00.000Z',
       completed_at: '2024-01-01T00:01:00.000Z',
       created_at: '2024-01-01T00:00:00.000Z',
+      steps: [
+        {
+          key: 'trigger_1',
+          type: 'trigger',
+          status: 'completed',
+          output: null,
+          error: null,
+          started_at: '2024-01-01T00:00:00.000Z',
+          completed_at: '2024-01-01T00:00:01.000Z',
+          created_at: '2024-01-01T00:00:00.000Z',
+        },
+      ],
     };
 
     mockSuccessResponse(response, {});
@@ -52,12 +60,18 @@ describe('get', () => {
             "object": "automation_run",
             "started_at": "2024-01-01T00:00:00.000Z",
             "status": "completed",
-            "trigger": {
-              "event_name": "user.created",
-              "payload": {
-                "email": "jane@example.com",
+            "steps": [
+              {
+                "completed_at": "2024-01-01T00:00:01.000Z",
+                "created_at": "2024-01-01T00:00:00.000Z",
+                "error": null,
+                "key": "trigger_1",
+                "output": null,
+                "started_at": "2024-01-01T00:00:00.000Z",
+                "status": "completed",
+                "type": "trigger",
               },
-            },
+            ],
           },
           "error": null,
           "headers": {
@@ -95,7 +109,6 @@ describe('list', () => {
         {
           id: 'wr_456',
           status: 'completed',
-          trigger: { event_name: 'user.created' },
           started_at: '2024-01-01T00:00:00.000Z',
           completed_at: '2024-01-01T00:01:00.000Z',
           created_at: '2024-01-01T00:00:00.000Z',
@@ -119,9 +132,6 @@ describe('list', () => {
                 "id": "wr_456",
                 "started_at": "2024-01-01T00:00:00.000Z",
                 "status": "completed",
-                "trigger": {
-                  "event_name": "user.created",
-                },
               },
             ],
             "has_more": false,
@@ -147,7 +157,6 @@ describe('list', () => {
         {
           id: 'wr_789',
           status: 'running',
-          trigger: null,
           started_at: '2024-01-02T00:00:00.000Z',
           completed_at: null,
           created_at: '2024-01-02T00:00:00.000Z',
@@ -171,7 +180,6 @@ describe('list', () => {
                 "id": "wr_789",
                 "started_at": "2024-01-02T00:00:00.000Z",
                 "status": "running",
-                "trigger": null,
               },
             ],
             "has_more": true,
@@ -183,6 +191,31 @@ describe('list', () => {
           },
         }
       `);
+  });
+
+  it('lists automation runs with status filter', async () => {
+    const options: ListAutomationRunsOptions = {
+      automationId: 'wf_123',
+      status: ['running', 'failed'],
+    };
+    const response: ListAutomationRunsResponseSuccess = {
+      object: 'list',
+      data: [],
+      has_more: false,
+    };
+
+    mockSuccessResponse(response, {});
+
+    const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+    await resend.automations.runs.list(options);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.resend.com/automations/wf_123/runs?status=running%2Cfailed',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.any(Headers),
+      }),
+    );
   });
 
   it('returns error', async () => {

--- a/src/automation-runs/automation-runs.ts
+++ b/src/automation-runs/automation-runs.ts
@@ -27,8 +27,18 @@ export class AutomationRuns {
     options: ListAutomationRunsOptions,
   ): Promise<ListAutomationRunsResponse> {
     const queryString = buildPaginationQuery(options);
-    const url = queryString
-      ? `/automations/${options.automationId}/runs?${queryString}`
+    const searchParams = new URLSearchParams(queryString);
+
+    if (options.status) {
+      const statusValue = Array.isArray(options.status)
+        ? options.status.join(',')
+        : options.status;
+      searchParams.set('status', statusValue);
+    }
+
+    const qs = searchParams.toString();
+    const url = qs
+      ? `/automations/${options.automationId}/runs?${qs}`
       : `/automations/${options.automationId}/runs`;
 
     const data = await this.resend.get<ListAutomationRunsResponseSuccess>(url);

--- a/src/automation-runs/interfaces/automation-run.ts
+++ b/src/automation-runs/interfaces/automation-run.ts
@@ -1,7 +1,4 @@
-export interface AutomationRunTrigger {
-  event_name: string;
-  payload?: Record<string, unknown>;
-}
+import type { AutomationStepType } from '../../automations/interfaces/automation-step.interface';
 
 export type AutomationRunStatus =
   | 'running'
@@ -9,17 +6,36 @@ export type AutomationRunStatus =
   | 'failed'
   | 'cancelled';
 
-export interface AutomationRun {
-  object: 'automation_run';
-  id: string;
-  status: AutomationRunStatus;
-  trigger: AutomationRunTrigger | null;
+export type AutomationRunStepStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'skipped'
+  | 'waiting';
+
+export interface AutomationRunStep {
+  key: string;
+  type: AutomationStepType;
+  status: AutomationRunStepStatus;
+  output: Record<string, unknown> | null;
+  error: Record<string, unknown> | null;
   started_at: string | null;
   completed_at: string | null;
   created_at: string;
 }
 
+export interface AutomationRun {
+  object: 'automation_run';
+  id: string;
+  status: AutomationRunStatus;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  steps: AutomationRunStep[];
+}
+
 export type AutomationRunItem = Pick<
   AutomationRun,
-  'id' | 'status' | 'trigger' | 'started_at' | 'completed_at' | 'created_at'
+  'id' | 'status' | 'started_at' | 'completed_at' | 'created_at'
 >;

--- a/src/automation-runs/interfaces/list-automation-runs.interface.ts
+++ b/src/automation-runs/interfaces/list-automation-runs.interface.ts
@@ -3,10 +3,11 @@ import type {
   PaginationOptions,
 } from '../../common/interfaces/pagination-options.interface';
 import type { Response } from '../../interfaces';
-import type { AutomationRunItem } from './automation-run';
+import type { AutomationRunItem, AutomationRunStatus } from './automation-run';
 
 export type ListAutomationRunsOptions = PaginationOptions & {
   automationId: string;
+  status?: AutomationRunStatus | AutomationRunStatus[];
 };
 
 export type ListAutomationRunsResponseSuccess = PaginatedData<

--- a/src/automations/automations.spec.ts
+++ b/src/automations/automations.spec.ts
@@ -426,6 +426,80 @@ describe('update', () => {
     );
   });
 
+  it('updates automation steps only', async () => {
+    const id = '71cdfe68-cf79-473a-a9d7-21f91db6a526';
+    const response: UpdateAutomationResponseSuccess = {
+      object: 'automation',
+      id,
+    };
+
+    fetchMock.mockOnce(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+
+    await resend.automations.update(id, {
+      steps: [
+        {
+          key: 'trigger',
+          type: 'trigger',
+          config: { eventName: 'user.created' },
+        },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.resend.com/automations/${id}`,
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: expect.any(Headers),
+        body: JSON.stringify({
+          steps: [
+            {
+              key: 'trigger',
+              type: 'trigger',
+              config: { event_name: 'user.created' },
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it('updates automation connections only', async () => {
+    const id = '71cdfe68-cf79-473a-a9d7-21f91db6a526';
+    const response: UpdateAutomationResponseSuccess = {
+      object: 'automation',
+      id,
+    };
+
+    fetchMock.mockOnce(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+
+    await resend.automations.update(id, {
+      connections: [{ from: 'trigger', to: 'welcome_email', type: 'default' }],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.resend.com/automations/${id}`,
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: expect.any(Headers),
+        body: JSON.stringify({
+          connections: [
+            { from: 'trigger', to: 'welcome_email', type: 'default' },
+          ],
+        }),
+      }),
+    );
+  });
+
   it('updates automation name', async () => {
     const id = '71cdfe68-cf79-473a-a9d7-21f91db6a526';
     const response: UpdateAutomationResponseSuccess = {

--- a/src/automations/automations.spec.ts
+++ b/src/automations/automations.spec.ts
@@ -9,6 +9,7 @@ import type {
 import type { GetAutomationResponseSuccess } from './interfaces/get-automation.interface';
 import type { ListAutomationsResponseSuccess } from './interfaces/list-automation.interface';
 import type { RemoveAutomationResponseSuccess } from './interfaces/remove-automation.interface';
+import type { StopAutomationResponseSuccess } from './interfaces/stop-automation.interface';
 import type { UpdateAutomationResponseSuccess } from './interfaces/update-automation.interface';
 
 const fetchMocker = createFetchMock(vi);
@@ -229,6 +230,32 @@ describe('list', () => {
       );
     });
   });
+
+  describe('when status filter is provided', () => {
+    it('passes status param', async () => {
+      mockSuccessResponse(response, {
+        headers: {},
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      const result = await resend.automations.list({ status: 'enabled' });
+      expect(result).toEqual({
+        data: response,
+        error: null,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.resend.com/automations?status=enabled',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.any(Headers),
+        }),
+      );
+    });
+  });
 });
 
 describe('get', () => {
@@ -279,7 +306,7 @@ describe('get', () => {
       updated_at: '2025-01-01T00:00:00.000Z',
       steps: [
         {
-          id: 'step-1',
+          key: 'step-1',
           type: 'trigger',
           config: { event_name: 'user.created' },
         },
@@ -312,7 +339,7 @@ describe('get', () => {
                 "config": {
                   "event_name": "user.created",
                 },
-                "id": "step-1",
+                "key": "step-1",
                 "type": "trigger",
               },
             ],
@@ -361,12 +388,11 @@ describe('remove', () => {
 });
 
 describe('update', () => {
-  it('updates an automation', async () => {
+  it('updates automation status', async () => {
     const id = '71cdfe68-cf79-473a-a9d7-21f91db6a526';
     const response: UpdateAutomationResponseSuccess = {
       object: 'automation',
       id,
-      status: 'disabled',
     };
 
     fetchMock.mockOnce(JSON.stringify(response), {
@@ -382,7 +408,6 @@ describe('update', () => {
           "data": {
             "id": "71cdfe68-cf79-473a-a9d7-21f91db6a526",
             "object": "automation",
-            "status": "disabled",
           },
           "error": null,
           "headers": {
@@ -397,6 +422,75 @@ describe('update', () => {
         method: 'PATCH',
         headers: expect.any(Headers),
         body: JSON.stringify({ status: 'disabled' }),
+      }),
+    );
+  });
+
+  it('updates automation name', async () => {
+    const id = '71cdfe68-cf79-473a-a9d7-21f91db6a526';
+    const response: UpdateAutomationResponseSuccess = {
+      object: 'automation',
+      id,
+    };
+
+    fetchMock.mockOnce(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+
+    const data = await resend.automations.update(id, {
+      name: 'Updated Flow',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.resend.com/automations/${id}`,
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: expect.any(Headers),
+        body: JSON.stringify({ name: 'Updated Flow' }),
+      }),
+    );
+  });
+});
+
+describe('stop', () => {
+  it('stops an automation', async () => {
+    const id = '71cdfe68-cf79-473a-a9d7-21f91db6a526';
+    const response: StopAutomationResponseSuccess = {
+      object: 'automation',
+      id,
+      status: 'disabled',
+    };
+
+    fetchMock.mockOnce(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+
+    const data = await resend.automations.stop(id);
+    expect(data).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "71cdfe68-cf79-473a-a9d7-21f91db6a526",
+            "object": "automation",
+            "status": "disabled",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.resend.com/automations/${id}/stop`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.any(Headers),
       }),
     );
   });

--- a/src/automations/automations.spec.ts
+++ b/src/automations/automations.spec.ts
@@ -514,7 +514,7 @@ describe('update', () => {
       },
     });
 
-    const data = await resend.automations.update(id, {
+    await resend.automations.update(id, {
       name: 'Updated Flow',
     });
 

--- a/src/automations/automations.ts
+++ b/src/automations/automations.ts
@@ -1,6 +1,10 @@
 import { AutomationRuns } from '../automation-runs/automation-runs';
 import { buildPaginationQuery } from '../common/utils/build-pagination-query';
-import { parseAutomationToApiOptions } from '../common/utils/parse-automation-to-api-options';
+import {
+  parseAutomationToApiOptions,
+  parseConnection,
+  parseStepConfig,
+} from '../common/utils/parse-automation-to-api-options';
 import type { Resend } from '../resend';
 import type {
   CreateAutomationOptions,
@@ -91,14 +95,11 @@ export class Automations {
     if (payload.status !== undefined) {
       apiPayload.status = payload.status;
     }
-    if (payload.steps !== undefined && payload.connections !== undefined) {
-      const parsed = parseAutomationToApiOptions({
-        name: '',
-        steps: payload.steps,
-        connections: payload.connections,
-      });
-      apiPayload.steps = parsed.steps;
-      apiPayload.connections = parsed.connections;
+    if (payload.steps !== undefined) {
+      apiPayload.steps = payload.steps.map(parseStepConfig);
+    }
+    if (payload.connections !== undefined) {
+      apiPayload.connections = payload.connections.map(parseConnection);
     }
 
     const data = await this.resend.patch<UpdateAutomationResponseSuccess>(

--- a/src/automations/automations.ts
+++ b/src/automations/automations.ts
@@ -21,6 +21,10 @@ import type {
   RemoveAutomationResponseSuccess,
 } from './interfaces/remove-automation.interface';
 import type {
+  StopAutomationResponse,
+  StopAutomationResponseSuccess,
+} from './interfaces/stop-automation.interface';
+import type {
   UpdateAutomationOptions,
   UpdateAutomationResponse,
   UpdateAutomationResponseSuccess,
@@ -48,7 +52,14 @@ export class Automations {
     options: ListAutomationsOptions = {},
   ): Promise<ListAutomationsResponse> {
     const queryString = buildPaginationQuery(options);
-    const url = queryString ? `/automations?${queryString}` : '/automations';
+    const params = [queryString];
+
+    if (options.status) {
+      params.push(`status=${encodeURIComponent(options.status)}`);
+    }
+
+    const qs = params.filter(Boolean).join('&');
+    const url = qs ? `/automations?${qs}` : '/automations';
 
     const data = await this.resend.get<ListAutomationsResponseSuccess>(url);
     return data;
@@ -72,9 +83,34 @@ export class Automations {
     id: string,
     payload: UpdateAutomationOptions,
   ): Promise<UpdateAutomationResponse> {
+    const apiPayload: Record<string, unknown> = {};
+
+    if (payload.name !== undefined) {
+      apiPayload.name = payload.name;
+    }
+    if (payload.status !== undefined) {
+      apiPayload.status = payload.status;
+    }
+    if (payload.steps !== undefined && payload.connections !== undefined) {
+      const parsed = parseAutomationToApiOptions({
+        name: '',
+        steps: payload.steps,
+        connections: payload.connections,
+      });
+      apiPayload.steps = parsed.steps;
+      apiPayload.connections = parsed.connections;
+    }
+
     const data = await this.resend.patch<UpdateAutomationResponseSuccess>(
       `/automations/${id}`,
-      payload,
+      apiPayload,
+    );
+    return data;
+  }
+
+  async stop(id: string): Promise<StopAutomationResponse> {
+    const data = await this.resend.post<StopAutomationResponseSuccess>(
+      `/automations/${id}/stop`,
     );
     return data;
   }

--- a/src/automations/interfaces/automation-step.interface.ts
+++ b/src/automations/interfaces/automation-step.interface.ts
@@ -69,7 +69,7 @@ export interface ContactUpdateStepConfig {
   >;
 }
 
-export type ContactDeleteStepConfig = {};
+export type ContactDeleteStepConfig = Record<string, never>;
 
 export interface AddToSegmentStepConfig {
   segment_id: string;

--- a/src/automations/interfaces/automation-step.interface.ts
+++ b/src/automations/interfaces/automation-step.interface.ts
@@ -59,14 +59,33 @@ export interface WaitForEventStepConfig {
 
 export type ConditionStepConfig = ConditionRule;
 
+export interface ContactUpdateStepConfig {
+  first_name?: string | null | { var: string };
+  last_name?: string | null | { var: string };
+  unsubscribed?: boolean | { var: string };
+  properties?: Record<
+    string,
+    string | number | boolean | null | { var: string }
+  >;
+}
+
+export type ContactDeleteStepConfig = {};
+
+export interface AddToSegmentStepConfig {
+  segment_id: string;
+}
+
 export type AutomationStep =
   | { key: string; type: 'trigger'; config: TriggerStepConfig }
   | { key: string; type: 'delay'; config: DelayStepConfig }
   | { key: string; type: 'send_email'; config: SendEmailStepConfig }
   | { key: string; type: 'wait_for_event'; config: WaitForEventStepConfig }
-  | { key: string; type: 'condition'; config: ConditionStepConfig };
+  | { key: string; type: 'condition'; config: ConditionStepConfig }
+  | { key: string; type: 'contact_update'; config: ContactUpdateStepConfig }
+  | { key: string; type: 'contact_delete'; config: ContactDeleteStepConfig }
+  | { key: string; type: 'add_to_segment'; config: AddToSegmentStepConfig };
 
-export type AutomationEdgeType =
+export type AutomationConnectionType =
   | 'default'
   | 'condition_met'
   | 'condition_not_met'
@@ -76,20 +95,19 @@ export type AutomationEdgeType =
 export interface AutomationConnection {
   from: string;
   to: string;
-  type?: AutomationEdgeType;
+  type?: AutomationConnectionType;
 }
 
 export type AutomationStepType = AutomationStep['type'];
 
 export interface AutomationResponseStep {
-  id: string;
+  key: string;
   type: AutomationStepType;
   config: Record<string, unknown>;
 }
 
 export interface AutomationResponseConnection {
-  id: string;
-  from_step_id: string;
-  to_step_id: string;
-  type: AutomationEdgeType;
+  from: string;
+  to: string;
+  type: AutomationConnectionType;
 }

--- a/src/automations/interfaces/index.ts
+++ b/src/automations/interfaces/index.ts
@@ -4,4 +4,5 @@ export * from './create-automation-options.interface';
 export * from './get-automation.interface';
 export * from './list-automation.interface';
 export * from './remove-automation.interface';
+export * from './stop-automation.interface';
 export * from './update-automation.interface';

--- a/src/automations/interfaces/list-automation.interface.ts
+++ b/src/automations/interfaces/list-automation.interface.ts
@@ -3,9 +3,11 @@ import type {
   PaginationOptions,
 } from '../../common/interfaces/pagination-options.interface';
 import type { Response } from '../../interfaces';
-import type { Automation } from './automation';
+import type { Automation, AutomationStatus } from './automation';
 
-export type ListAutomationsOptions = PaginationOptions;
+export type ListAutomationsOptions = PaginationOptions & {
+  status?: AutomationStatus;
+};
 
 export type ListAutomationsResponseSuccess = PaginatedData<Automation[]>;
 

--- a/src/automations/interfaces/stop-automation.interface.ts
+++ b/src/automations/interfaces/stop-automation.interface.ts
@@ -1,0 +1,9 @@
+import type { Response } from '../../interfaces';
+
+export interface StopAutomationResponseSuccess {
+  object: 'automation';
+  id: string;
+  status: 'disabled';
+}
+
+export type StopAutomationResponse = Response<StopAutomationResponseSuccess>;

--- a/src/automations/interfaces/update-automation.interface.ts
+++ b/src/automations/interfaces/update-automation.interface.ts
@@ -1,12 +1,19 @@
 import type { Response } from '../../interfaces';
 import type { Automation, AutomationStatus } from './automation';
+import type {
+  AutomationConnection,
+  AutomationStep,
+} from './automation-step.interface';
 
 export interface UpdateAutomationOptions {
-  status: AutomationStatus;
+  name?: string;
+  status?: AutomationStatus;
+  steps?: AutomationStep[];
+  connections?: AutomationConnection[];
 }
 
 export interface UpdateAutomationResponseSuccess
-  extends Pick<Automation, 'id' | 'status'> {
+  extends Pick<Automation, 'id'> {
   object: 'automation';
 }
 

--- a/src/common/utils/parse-automation-to-api-options.spec.ts
+++ b/src/common/utils/parse-automation-to-api-options.spec.ts
@@ -85,11 +85,13 @@ describe('parseAutomationToApiOptions', () => {
           key: 'send_1',
           type: 'send_email',
           config: {
-            template_id: 'tmpl_123',
+            template: {
+              id: 'tmpl_123',
+              variables: { userName: { var: 'contact.name' } },
+            },
             subject: 'Welcome!',
             from: 'hello@example.com',
             reply_to: 'support@example.com',
-            variables: { userName: { var: 'contact.name' } },
           },
         },
         {
@@ -126,7 +128,7 @@ describe('parseAutomationToApiOptions', () => {
     });
   });
 
-  it('passes edge type through to API options', () => {
+  it('converts connection type field', () => {
     const automation: CreateAutomationOptions = {
       name: 'Edge Test',
       steps: [

--- a/src/common/utils/parse-automation-to-api-options.ts
+++ b/src/common/utils/parse-automation-to-api-options.ts
@@ -32,7 +32,9 @@ interface EventApiOptions {
   payload?: Record<string, unknown>;
 }
 
-export function parseStepConfig(step: AutomationStep): AutomationStepApiOptions {
+export function parseStepConfig(
+  step: AutomationStep,
+): AutomationStepApiOptions {
   switch (step.type) {
     case 'trigger':
       return {

--- a/src/common/utils/parse-automation-to-api-options.ts
+++ b/src/common/utils/parse-automation-to-api-options.ts
@@ -32,7 +32,7 @@ interface EventApiOptions {
   payload?: Record<string, unknown>;
 }
 
-function parseStepConfig(step: AutomationStep): AutomationStepApiOptions {
+export function parseStepConfig(step: AutomationStep): AutomationStepApiOptions {
   switch (step.type) {
     case 'trigger':
       return {
@@ -77,7 +77,7 @@ function parseStepConfig(step: AutomationStep): AutomationStepApiOptions {
   }
 }
 
-function parseConnection(
+export function parseConnection(
   connection: AutomationConnection,
 ): AutomationConnectionApiOptions {
   return {

--- a/src/common/utils/parse-automation-to-api-options.ts
+++ b/src/common/utils/parse-automation-to-api-options.ts
@@ -1,6 +1,6 @@
 import type {
   AutomationConnection,
-  AutomationEdgeType,
+  AutomationConnectionType,
   AutomationStep,
 } from '../../automations/interfaces/automation-step.interface';
 import type { CreateAutomationOptions } from '../../automations/interfaces/create-automation-options.interface';
@@ -15,7 +15,7 @@ interface AutomationStepApiOptions {
 interface AutomationConnectionApiOptions {
   from: string;
   to: string;
-  type?: AutomationEdgeType;
+  type?: AutomationConnectionType;
 }
 
 interface AutomationApiOptions {
@@ -47,11 +47,13 @@ function parseStepConfig(step: AutomationStep): AutomationStepApiOptions {
         key: step.key,
         type: step.type,
         config: {
-          template_id: step.config.templateId,
+          template: {
+            id: step.config.templateId,
+            variables: step.config.variables,
+          },
           subject: step.config.subject,
           from: step.config.from,
           reply_to: step.config.replyTo,
-          variables: step.config.variables,
         },
       };
     case 'wait_for_event':
@@ -65,6 +67,12 @@ function parseStepConfig(step: AutomationStep): AutomationStepApiOptions {
         },
       };
     case 'condition':
+      return { key: step.key, type: step.type, config: step.config };
+    case 'contact_update':
+      return { key: step.key, type: step.type, config: step.config };
+    case 'contact_delete':
+      return { key: step.key, type: step.type, config: step.config };
+    case 'add_to_segment':
       return { key: step.key, type: step.type, config: step.config };
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds preview support for Automations and Events, replaces the old Workflows preview, and matches the SDK to the latest API (connections, step keys, run steps). Adds status filters to list endpoints and a new stop endpoint.

- **New Features**
  - `resend.automations`: create, list (pagination + `status`), get, update (name, status, steps, or connections independently), remove, stop.
  - `resend.automations.runs`: get and list (pagination + `status` array or string); run responses include `steps`.
  - `resend.events`: send (by `contactId` or `email`), create, list (pagination), get, update, remove.
  - New step types: `contact_update`, `contact_delete`, `add_to_segment`.
  - Automatic payload mapping: camelCase → API fields (e.g., `eventName` → `event_name`, `replyTo` → `reply_to`, `templateId` → `template.id`, `variables` → `template.variables`).

- **Migration**
  - Replace `resend.workflows` with `resend.automations`.
  - Use `connections` (with `type`) instead of `edges` (with `edgeType`) in create/update; responses return `connections` (from/to/type) and step `key`s. Steps/configs stay camelCase; the SDK maps to API.
  - `AutomationRun.trigger` removed; use `steps` for run details.

<sup>Written for commit d706d30b61708ee581ac3a7b617dcbfc4cc27448. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

