### PR TITLE
refactor: edge type

### DIFF
--- a/src/automations/automations.spec.ts
+++ b/src/automations/automations.spec.ts
@@ -48,7 +48,7 @@ describe('create', () => {
           config: { templateId: 'tpl-123' },
         },
       ],
-      edges: [{ from: 'trigger', to: 'welcome_email', edgeType: 'default' }],
+      edges: [{ from: 'trigger', to: 'welcome_email', type: 'default' }],
     };
 
     const data = await resend.automations.create(payload);

--- a/src/automations/interfaces/automation-step.interface.ts
+++ b/src/automations/interfaces/automation-step.interface.ts
@@ -76,7 +76,7 @@ export type AutomationEdgeType =
 export interface AutomationEdge {
   from: string;
   to: string;
-  edgeType?: AutomationEdgeType;
+  type?: AutomationEdgeType;
 }
 
 export type AutomationStepType = AutomationStep['type'];
@@ -91,5 +91,5 @@ export interface AutomationResponseEdge {
   id: string;
   from_step_id: string;
   to_step_id: string;
-  edge_type: AutomationEdgeType;
+  type: AutomationEdgeType;
 }

--- a/src/common/utils/parse-automation-to-api-options.spec.ts
+++ b/src/common/utils/parse-automation-to-api-options.spec.ts
@@ -59,9 +59,9 @@ describe('parseAutomationToApiOptions', () => {
       ],
       edges: [
         { from: 'trigger_1', to: 'delay_1' },
-        { from: 'delay_1', to: 'send_1', edgeType: 'default' },
+        { from: 'delay_1', to: 'send_1', type: 'default' },
         { from: 'send_1', to: 'wait_1' },
-        { from: 'wait_1', to: 'cond_1', edgeType: 'event_received' },
+        { from: 'wait_1', to: 'cond_1', type: 'event_received' },
       ],
     };
 
@@ -118,15 +118,15 @@ describe('parseAutomationToApiOptions', () => {
         },
       ],
       edges: [
-        { from: 'trigger_1', to: 'delay_1', edge_type: undefined },
-        { from: 'delay_1', to: 'send_1', edge_type: 'default' },
-        { from: 'send_1', to: 'wait_1', edge_type: undefined },
-        { from: 'wait_1', to: 'cond_1', edge_type: 'event_received' },
+        { from: 'trigger_1', to: 'delay_1', type: undefined },
+        { from: 'delay_1', to: 'send_1', type: 'default' },
+        { from: 'send_1', to: 'wait_1', type: undefined },
+        { from: 'wait_1', to: 'cond_1', type: 'event_received' },
       ],
     });
   });
 
-  it('converts edge edgeType to edge_type', () => {
+  it('passes edge type through to API options', () => {
     const automation: CreateAutomationOptions = {
       name: 'Edge Test',
       steps: [
@@ -137,18 +137,18 @@ describe('parseAutomationToApiOptions', () => {
         },
       ],
       edges: [
-        { from: 'trigger_1', to: 'step_2', edgeType: 'condition_met' },
-        { from: 'trigger_1', to: 'step_3', edgeType: 'condition_not_met' },
-        { from: 'step_2', to: 'step_4', edgeType: 'timeout' },
+        { from: 'trigger_1', to: 'step_2', type: 'condition_met' },
+        { from: 'trigger_1', to: 'step_3', type: 'condition_not_met' },
+        { from: 'step_2', to: 'step_4', type: 'timeout' },
       ],
     };
 
     const apiOptions = parseAutomationToApiOptions(automation);
 
     expect(apiOptions.edges).toEqual([
-      { from: 'trigger_1', to: 'step_2', edge_type: 'condition_met' },
-      { from: 'trigger_1', to: 'step_3', edge_type: 'condition_not_met' },
-      { from: 'step_2', to: 'step_4', edge_type: 'timeout' },
+      { from: 'trigger_1', to: 'step_2', type: 'condition_met' },
+      { from: 'trigger_1', to: 'step_3', type: 'condition_not_met' },
+      { from: 'step_2', to: 'step_4', type: 'timeout' },
     ]);
   });
 
@@ -177,7 +177,7 @@ describe('parseAutomationToApiOptions', () => {
           config: { event_name: 'test.event' },
         },
       ],
-      edges: [{ from: 'trigger_1', to: 'step_2', edge_type: undefined }],
+      edges: [{ from: 'trigger_1', to: 'step_2', type: undefined }],
     });
   });
 });

--- a/src/common/utils/parse-automation-to-api-options.ts
+++ b/src/common/utils/parse-automation-to-api-options.ts
@@ -15,7 +15,7 @@ interface AutomationStepApiOptions {
 interface AutomationEdgeApiOptions {
   from: string;
   to: string;
-  edge_type?: AutomationEdgeType;
+  type?: AutomationEdgeType;
 }
 
 interface AutomationApiOptions {
@@ -73,7 +73,7 @@ function parseEdge(edge: AutomationEdge): AutomationEdgeApiOptions {
   return {
     from: edge.from,
     to: edge.to,
-    edge_type: edge.edgeType,
+    type: edge.type,
   };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Automations and Events APIs to the SDK with support for creating, listing, getting, updating, and removing automations and events, plus sending events and listing/getting automation runs. Exposes `resend.automations` (with nested `runs`) and `resend.events`, and bumps to `6.10.0-preview-workflows.5`.

- **New Features**
  - `resend.automations`: create/list/get/update/remove; pagination supported; edges with typed `type`; includes `runs.get({ automationId, runId })` and `runs.list({ automationId, ...pagination })`.
  - `resend.events`: send by `contactId` or `email`; create/list/get/update/remove; pagination and safe identifier encoding.
  - Utils: `parseAutomationToApiOptions` and `parseEventToApiOptions` map camelCase to API snake_case (e.g., `eventName`→`event_name`, `templateId`→`template_id`, `contactId`→`contact_id`).
  - Exports: new `automation-runs`, `automations`, and `events` interfaces re-exported from `src/index.ts`.
  - Version: package set to `6.10.0-preview-workflows.5`.

- **Migration**
  - Use `resend.automations` (replaces any prior “workflows” usage) and `resend.events`.
  - Provide step configs in camelCase; the SDK converts to API format.
  - Automation run endpoints now accessed via `resend.automations.runs.get()` and `.list()` with `{ limit, after, before }`.

<sup>Written for commit 83699734f783cb81779755251413d06a9662c87b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

