### PR TITLE
refactor: rename edges

### DIFF
--- a/src/automations/automations.spec.ts
+++ b/src/automations/automations.spec.ts
@@ -48,7 +48,9 @@ describe('create', () => {
           config: { templateId: 'tpl-123' },
         },
       ],
-      edges: [{ from: 'trigger', to: 'welcome_email', type: 'default' }],
+      connections: [
+        { from: 'trigger', to: 'welcome_email', type: 'default' },
+      ],
     };
 
     const data = await resend.automations.create(payload);
@@ -83,7 +85,7 @@ describe('create', () => {
     const data = await resend.automations.create({
       name: '',
       steps: [],
-      edges: [],
+      connections: [],
     });
     expect(data).toMatchInlineSnapshot(`
         {
@@ -284,7 +286,7 @@ describe('get', () => {
           config: { event_name: 'user.created' },
         },
       ],
-      edges: [],
+      connections: [],
     };
 
     fetchMock.mockOnce(JSON.stringify(response), {
@@ -301,8 +303,8 @@ describe('get', () => {
     ).resolves.toMatchInlineSnapshot(`
         {
           "data": {
+            "connections": [],
             "created_at": "2025-01-01T00:00:00.000Z",
-            "edges": [],
             "id": "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
             "name": "Welcome Flow",
             "object": "automation",

--- a/src/automations/automations.spec.ts
+++ b/src/automations/automations.spec.ts
@@ -48,9 +48,7 @@ describe('create', () => {
           config: { templateId: 'tpl-123' },
         },
       ],
-      connections: [
-        { from: 'trigger', to: 'welcome_email', type: 'default' },
-      ],
+      connections: [{ from: 'trigger', to: 'welcome_email', type: 'default' }],
     };
 
     const data = await resend.automations.create(payload);

--- a/src/automations/interfaces/automation-step.interface.ts
+++ b/src/automations/interfaces/automation-step.interface.ts
@@ -73,7 +73,7 @@ export type AutomationEdgeType =
   | 'timeout'
   | 'event_received';
 
-export interface AutomationEdge {
+export interface AutomationConnection {
   from: string;
   to: string;
   type?: AutomationEdgeType;
@@ -87,7 +87,7 @@ export interface AutomationResponseStep {
   config: Record<string, unknown>;
 }
 
-export interface AutomationResponseEdge {
+export interface AutomationResponseConnection {
   id: string;
   from_step_id: string;
   to_step_id: string;

--- a/src/automations/interfaces/create-automation-options.interface.ts
+++ b/src/automations/interfaces/create-automation-options.interface.ts
@@ -1,7 +1,7 @@
 import type { Response } from '../../interfaces';
 import type { AutomationStatus } from './automation';
 import type {
-  AutomationEdge,
+  AutomationConnection,
   AutomationStep,
 } from './automation-step.interface';
 
@@ -9,7 +9,7 @@ export interface CreateAutomationOptions {
   name: string;
   status?: AutomationStatus;
   steps: AutomationStep[];
-  edges: AutomationEdge[];
+  connections: AutomationConnection[];
 }
 
 export interface CreateAutomationResponseSuccess {

--- a/src/automations/interfaces/get-automation.interface.ts
+++ b/src/automations/interfaces/get-automation.interface.ts
@@ -1,14 +1,14 @@
 import type { Response } from '../../interfaces';
 import type { Automation } from './automation';
 import type {
-  AutomationResponseEdge,
+  AutomationResponseConnection,
   AutomationResponseStep,
 } from './automation-step.interface';
 
 export interface GetAutomationResponseSuccess extends Automation {
   object: 'automation';
   steps: AutomationResponseStep[];
-  edges: AutomationResponseEdge[];
+  connections: AutomationResponseConnection[];
 }
 
 export type GetAutomationResponse = Response<GetAutomationResponseSuccess>;

--- a/src/common/utils/parse-automation-to-api-options.spec.ts
+++ b/src/common/utils/parse-automation-to-api-options.spec.ts
@@ -57,7 +57,7 @@ describe('parseAutomationToApiOptions', () => {
           },
         },
       ],
-      edges: [
+      connections: [
         { from: 'trigger_1', to: 'delay_1' },
         { from: 'delay_1', to: 'send_1', type: 'default' },
         { from: 'send_1', to: 'wait_1' },
@@ -117,7 +117,7 @@ describe('parseAutomationToApiOptions', () => {
           },
         },
       ],
-      edges: [
+      connections: [
         { from: 'trigger_1', to: 'delay_1', type: undefined },
         { from: 'delay_1', to: 'send_1', type: 'default' },
         { from: 'send_1', to: 'wait_1', type: undefined },
@@ -128,7 +128,7 @@ describe('parseAutomationToApiOptions', () => {
 
   it('passes edge type through to API options', () => {
     const automation: CreateAutomationOptions = {
-      name: 'Edge Test',
+      name: 'Connection Test',
       steps: [
         {
           key: 'trigger_1',
@@ -136,7 +136,7 @@ describe('parseAutomationToApiOptions', () => {
           config: { eventName: 'test.event' },
         },
       ],
-      edges: [
+      connections: [
         { from: 'trigger_1', to: 'step_2', type: 'condition_met' },
         { from: 'trigger_1', to: 'step_3', type: 'condition_not_met' },
         { from: 'step_2', to: 'step_4', type: 'timeout' },
@@ -145,7 +145,7 @@ describe('parseAutomationToApiOptions', () => {
 
     const apiOptions = parseAutomationToApiOptions(automation);
 
-    expect(apiOptions.edges).toEqual([
+    expect(apiOptions.connections).toEqual([
       { from: 'trigger_1', to: 'step_2', type: 'condition_met' },
       { from: 'trigger_1', to: 'step_3', type: 'condition_not_met' },
       { from: 'step_2', to: 'step_4', type: 'timeout' },
@@ -162,7 +162,7 @@ describe('parseAutomationToApiOptions', () => {
           config: { eventName: 'test.event' },
         },
       ],
-      edges: [{ from: 'trigger_1', to: 'step_2' }],
+      connections: [{ from: 'trigger_1', to: 'step_2' }],
     };
 
     const apiOptions = parseAutomationToApiOptions(automation);
@@ -177,7 +177,7 @@ describe('parseAutomationToApiOptions', () => {
           config: { event_name: 'test.event' },
         },
       ],
-      edges: [{ from: 'trigger_1', to: 'step_2', type: undefined }],
+      connections: [{ from: 'trigger_1', to: 'step_2', type: undefined }],
     });
   });
 });

--- a/src/common/utils/parse-automation-to-api-options.spec.ts
+++ b/src/common/utils/parse-automation-to-api-options.spec.ts
@@ -128,7 +128,7 @@ describe('parseAutomationToApiOptions', () => {
 
   it('passes edge type through to API options', () => {
     const automation: CreateAutomationOptions = {
-      name: 'Connection Test',
+      name: 'Edge Test',
       steps: [
         {
           key: 'trigger_1',

--- a/src/common/utils/parse-automation-to-api-options.ts
+++ b/src/common/utils/parse-automation-to-api-options.ts
@@ -1,5 +1,5 @@
 import type {
-  AutomationEdge,
+  AutomationConnection,
   AutomationEdgeType,
   AutomationStep,
 } from '../../automations/interfaces/automation-step.interface';
@@ -12,7 +12,7 @@ interface AutomationStepApiOptions {
   config: unknown;
 }
 
-interface AutomationEdgeApiOptions {
+interface AutomationConnectionApiOptions {
   from: string;
   to: string;
   type?: AutomationEdgeType;
@@ -22,7 +22,7 @@ interface AutomationApiOptions {
   name: string;
   status?: 'enabled' | 'disabled';
   steps?: AutomationStepApiOptions[];
-  edges?: AutomationEdgeApiOptions[];
+  connections?: AutomationConnectionApiOptions[];
 }
 
 interface EventApiOptions {
@@ -69,11 +69,13 @@ function parseStepConfig(step: AutomationStep): AutomationStepApiOptions {
   }
 }
 
-function parseEdge(edge: AutomationEdge): AutomationEdgeApiOptions {
+function parseConnection(
+  connection: AutomationConnection,
+): AutomationConnectionApiOptions {
   return {
-    from: edge.from,
-    to: edge.to,
-    type: edge.type,
+    from: connection.from,
+    to: connection.to,
+    type: connection.type,
   };
 }
 
@@ -84,7 +86,7 @@ export function parseAutomationToApiOptions(
     name: automation.name,
     status: automation.status,
     steps: automation.steps.map(parseStepConfig),
-    edges: automation.edges.map(parseEdge),
+    connections: automation.connections.map(parseConnection),
   };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed automation graph “edges” to “connections” across the SDK to match the API. This is a breaking rename of request/response fields; behavior is unchanged.

- **Refactors**
  - Create payload: edges[] → connections[]; items keep type.
  - Get response: edges[] → connections[]; items still use edge_type.
  - Renamed interfaces: AutomationEdge → AutomationConnection; AutomationResponseEdge → AutomationResponseConnection.
  - Updated parseAutomationToApiOptions to emit connections with type.
  - Updated tests for new naming and formatted connections arrays to satisfy `biome`.

- **Migration**
  - Replace edges with connections in CreateAutomationOptions and response handling.
  - Use type in client payloads; response items still include edge_type.

<sup>Written for commit 8a410d84d24c49b5292b031403c623a9c916e6ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

