### PR TITLE
fix: template object structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.10.0-preview-workflows.6",
+  "version": "6.10.0-preview-workflows.7",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/automations/automations.spec.ts
+++ b/src/automations/automations.spec.ts
@@ -46,7 +46,7 @@ describe('create', () => {
         {
           key: 'welcome_email',
           type: 'send_email',
-          config: { templateId: 'tpl-123' },
+          config: { template: { id: 'tpl-123' } },
         },
       ],
       connections: [{ from: 'trigger', to: 'welcome_email', type: 'default' }],

--- a/src/automations/interfaces/automation-step.interface.ts
+++ b/src/automations/interfaces/automation-step.interface.ts
@@ -44,11 +44,13 @@ export interface DelayStepConfig {
 }
 
 export interface SendEmailStepConfig {
-  templateId: string;
+  template: {
+    id: string;
+    variables?: Record<string, TemplateVariableValue>;
+  };
   subject?: string;
   from?: string;
   replyTo?: string;
-  variables?: Record<string, TemplateVariableValue>;
 }
 
 export interface WaitForEventStepConfig {

--- a/src/common/utils/parse-automation-to-api-options.spec.ts
+++ b/src/common/utils/parse-automation-to-api-options.spec.ts
@@ -25,11 +25,13 @@ describe('parseAutomationToApiOptions', () => {
           key: 'send_1',
           type: 'send_email',
           config: {
-            templateId: 'tmpl_123',
+            template: {
+              id: 'tmpl_123',
+              variables: { userName: { var: 'contact.name' } },
+            },
             subject: 'Welcome!',
             from: 'hello@example.com',
             replyTo: 'support@example.com',
-            variables: { userName: { var: 'contact.name' } },
           },
         },
         {

--- a/src/common/utils/parse-automation-to-api-options.ts
+++ b/src/common/utils/parse-automation-to-api-options.ts
@@ -49,10 +49,7 @@ export function parseStepConfig(
         key: step.key,
         type: step.type,
         config: {
-          template: {
-            id: step.config.templateId,
-            variables: step.config.variables,
-          },
+          template: step.config.template,
           subject: step.config.subject,
           from: step.config.from,
           reply_to: step.config.replyTo,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the send_email step to use a nested template object that matches the API. Replaces `templateId` and root-level `variables` with `config.template: { id, variables? }`.

- **Bug Fixes**
  - Updated send email config to `template: { id, variables? }`.
  - Parser now passes `config.template` through directly and keeps `reply_to` mapping.
  - Tests updated; bumped `resend` to 6.10.0-preview-workflows.7.

<sup>Written for commit 535bec84dbea0470acdc0ba809cd9d730d500d94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

