### PR TITLE
chore: bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.10.0-preview-workflows.7",
+  "version": "6.11.0-canary.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `resend` package version from 6.10.0-preview-workflows.7 to 6.11.0-canary.0 to prepare the next canary release.

<sup>Written for commit 63359cdd5dab151a76ab3d411388700f009aced7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

