### PR TITLE
fix: case conventions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.11.0-canary.0",
+  "version": "6.11.0-canary.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/automations/interfaces/automation-step.interface.ts
+++ b/src/automations/interfaces/automation-step.interface.ts
@@ -62,8 +62,8 @@ export interface WaitForEventStepConfig {
 export type ConditionStepConfig = ConditionRule;
 
 export interface ContactUpdateStepConfig {
-  first_name?: string | null | { var: string };
-  last_name?: string | null | { var: string };
+  firstName?: string | null | { var: string };
+  lastName?: string | null | { var: string };
   unsubscribed?: boolean | { var: string };
   properties?: Record<
     string,
@@ -74,7 +74,7 @@ export interface ContactUpdateStepConfig {
 export type ContactDeleteStepConfig = Record<string, never>;
 
 export interface AddToSegmentStepConfig {
-  segment_id: string;
+  segmentId: string;
 }
 
 export type AutomationStep =

--- a/src/common/utils/parse-automation-to-api-options.spec.ts
+++ b/src/common/utils/parse-automation-to-api-options.spec.ts
@@ -58,6 +58,26 @@ describe('parseAutomationToApiOptions', () => {
             value: 'pro',
           },
         },
+        {
+          key: 'update_1',
+          type: 'contact_update',
+          config: {
+            firstName: 'Jane',
+            lastName: { var: 'payload.last_name' },
+            unsubscribed: false,
+            properties: { plan: 'pro' },
+          },
+        },
+        {
+          key: 'delete_1',
+          type: 'contact_delete',
+          config: {},
+        },
+        {
+          key: 'segment_1',
+          type: 'add_to_segment',
+          config: { segmentId: 'seg_abc123' },
+        },
       ],
       connections: [
         { from: 'trigger_1', to: 'delay_1' },
@@ -119,6 +139,26 @@ describe('parseAutomationToApiOptions', () => {
             operator: 'eq',
             value: 'pro',
           },
+        },
+        {
+          key: 'update_1',
+          type: 'contact_update',
+          config: {
+            first_name: 'Jane',
+            last_name: { var: 'payload.last_name' },
+            unsubscribed: false,
+            properties: { plan: 'pro' },
+          },
+        },
+        {
+          key: 'delete_1',
+          type: 'contact_delete',
+          config: {},
+        },
+        {
+          key: 'segment_1',
+          type: 'add_to_segment',
+          config: { segment_id: 'seg_abc123' },
         },
       ],
       connections: [

--- a/src/common/utils/parse-automation-to-api-options.ts
+++ b/src/common/utils/parse-automation-to-api-options.ts
@@ -68,11 +68,24 @@ export function parseStepConfig(
     case 'condition':
       return { key: step.key, type: step.type, config: step.config };
     case 'contact_update':
-      return { key: step.key, type: step.type, config: step.config };
+      return {
+        key: step.key,
+        type: step.type,
+        config: {
+          first_name: step.config.firstName,
+          last_name: step.config.lastName,
+          unsubscribed: step.config.unsubscribed,
+          properties: step.config.properties,
+        },
+      };
     case 'contact_delete':
       return { key: step.key, type: step.type, config: step.config };
     case 'add_to_segment':
-      return { key: step.key, type: step.type, config: step.config };
+      return {
+        key: step.key,
+        type: step.type,
+        config: { segment_id: step.config.segmentId },
+      };
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized automation step configs to camelCase internally and added mapping to snake_case for API payloads. Fixes mismatched field names in contact update and add-to-segment steps.

- **Bug Fixes**
  - Updated types to use firstName/lastName and segmentId; parser now outputs first_name/last_name/segment_id for the API.
  - Added tests for the mapping; bumped `resend` to 6.11.0-canary.1.

<sup>Written for commit e2bbb9f0ec99f978f438b2d667886f6489305840. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

