### PR TITLE
chore: bump to 6.11.0 for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.11.0-canary.1",
+  "version": "6.11.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Bumping to new minor version for releasing the SDK.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `resend` 6.11.0 by removing the canary suffix in package.json. No code changes.

<sup>Written for commit d526108b06b47df1d3ca475a7d0b9f54d740640d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

