### PR TITLE
feat(domains): add TrackingCAA record support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.10.0-preview-tracking-domains.3",
+  "version": "6.10.0-preview-tracking-domains.4",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/domains/domains.spec.ts
+++ b/src/domains/domains.spec.ts
@@ -508,6 +508,14 @@ describe('Domains', () => {
               status: 'not_started',
               ttl: 'Auto',
             },
+            {
+              record: 'TrackingCAA',
+              name: '',
+              value: '0 issue "amazon.com"',
+              type: 'CAA',
+              status: 'not_started',
+              ttl: 'Auto',
+            },
           ],
           region: 'us-east-1',
         };
@@ -532,6 +540,9 @@ describe('Domains', () => {
         expect(result.data?.click_tracking).toBe(true);
         expect(result.data?.records).toContainEqual(
           expect.objectContaining({ record: 'Tracking' }),
+        );
+        expect(result.data?.records).toContainEqual(
+          expect.objectContaining({ record: 'TrackingCAA' }),
         );
         expect(result.error).toBeNull();
       });
@@ -991,6 +1002,14 @@ describe('Domains', () => {
             ttl: 'Auto',
             status: 'verified',
           },
+          {
+            record: 'TrackingCAA',
+            name: '',
+            value: '0 issue "amazon.com"',
+            type: 'CAA',
+            ttl: 'Auto',
+            status: 'verified',
+          },
         ],
       };
 
@@ -1058,6 +1077,14 @@ describe('Domains', () => {
                 "ttl": "Auto",
                 "type": "CNAME",
                 "value": "tracking.resend.com",
+              },
+              {
+                "name": "",
+                "record": "TrackingCAA",
+                "status": "verified",
+                "ttl": "Auto",
+                "type": "CAA",
+                "value": "0 issue "amazon.com"",
               },
             ],
             "region": "us-east-1",

--- a/src/domains/interfaces/domain.ts
+++ b/src/domains/interfaces/domain.ts
@@ -32,7 +32,8 @@ export type DomainRecords =
   | DomainSpfRecord
   | DomainDkimRecord
   | ReceivingRecord
-  | TrackingRecord;
+  | TrackingRecord
+  | TrackingCaaRecord;
 
 export interface DomainSpfRecord {
   record: 'SPF';
@@ -73,6 +74,15 @@ export interface TrackingRecord {
   name: string;
   value: string;
   type: 'CNAME';
+  ttl: string;
+  status: DomainStatus;
+}
+
+export interface TrackingCaaRecord {
+  record: 'TrackingCAA';
+  name: string;
+  value: string;
+  type: 'CAA';
   ttl: string;
   status: DomainStatus;
 }


### PR DESCRIPTION
## Summary

The Domains API now returns an extra DNS record on `POST /domains` and `GET /domains/:id` when a tracking subdomain is configured **and** the customer's root domain has CAA records that would prevent AWS from issuing a certificate for the tracking subdomain:

```json
{
  "record": "TrackingCAA",
  "name": "",
  "type": "CAA",
  "ttl": "Auto",
  "value": "0 issue \"amazon.com\"",
  "status": "verified"
}
```

This PR adds the new `TrackingCaaRecord` variant to the `DomainRecords` discriminated union so consumers can narrow on `record === 'TrackingCAA'`, and extends the existing tracking-subdomain and get-domain test fixtures to include the new record.

## Test plan

- [x] `pnpm test src/domains/domains.spec.ts` — 22 passed (including the new `TrackingCAA` assertions and snapshot)
- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean

Tracking: [Linear ENG-4842](https://linear.app/resend/issue/ENG-4842/nodejs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)