### PR TITLE
chore(ci): use depot

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   e2e:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-8
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   lint:
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   pin-dependencies-check:
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   pr-title-check:
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-2
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -12,7 +12,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-8
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-22.04-8
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update-docs:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-2
     name: Trigger Mintlify Agent
     if: github.repository == 'resend/resend-node'
     permissions:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch GitHub Actions to Depot runners to speed up CI and standardize on Ubuntu 22.04. Replaces `blacksmith-*` and `ubuntu-latest` with `depot-ubuntu-22.04-{2,8}` to match job size.

- **Refactors**
  - e2e, tests, preview-release → `depot-ubuntu-22.04-8`; lint, pin-dependencies, PR title check, update-docs → `depot-ubuntu-22.04-2`.

<sup>Written for commit 28acc30175e5b265534444badd75dbfe77b378fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

