### PR TITLE
chore(ci): revert from Depot to Blacksmith runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   e2e:
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   lint:
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   pin-dependencies-check:
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   pr-title-check:
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -12,7 +12,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     permissions: 
       contents: write
       pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   tests:
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
       image: node:24-slim
       # credentials:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update-docs:
-    runs-on: depot-ubuntu-22.04-2
+    runs-on: ubuntu-latest
     name: Trigger Mintlify Agent
     if: github.repository == 'resend/resend-node'
     permissions:


### PR DESCRIPTION
## Summary
- Reverts all CI workflows from Depot runners back to Blacksmith runners (the configuration prior to #931)
- `e2e`, `tests`, `preview-release`: `blacksmith-4vcpu-ubuntu-2204`
- `lint`, `pin-dependencies-check`, `pr-title-check`: `blacksmith-2vcpu-ubuntu-2204`
- `update-docs`: `ubuntu-latest` (unchanged from pre-Depot config)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts all CI workflows from Depot runners back to Blacksmith to restore the pre-#931 setup and keep jobs consistent.

- **Refactors**
  - e2e, tests, preview-release → blacksmith-4vcpu-ubuntu-2204
  - lint, pin-dependencies-check, pr-title-check → blacksmith-2vcpu-ubuntu-2204
  - update-docs → ubuntu-latest (unchanged from prior setup)

<sup>Written for commit 867d76dc26f9869a325b95d220fb0a419c4c906f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

