### PR TITLE
fix: add new domain statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.12.1",
+  "version": "6.12.2",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/domains/domains.spec.ts
+++ b/src/domains/domains.spec.ts
@@ -1098,6 +1098,99 @@ describe('Domains', () => {
         }
       `);
     });
+
+    it('get partially_verified domain', async () => {
+      const response: GetDomainResponseSuccess = {
+        object: 'domain',
+        id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+        name: 'resend.com',
+        status: 'partially_verified',
+        created_at: '2023-06-21T06:10:36.144Z',
+        region: 'us-east-1',
+        click_tracking: true,
+        tracking_subdomain: 'track',
+        capabilities: {
+          sending: 'enabled',
+          receiving: 'disabled',
+        },
+        records: [
+          {
+            record: 'DKIM',
+            name: 'resend._domainkey',
+            value: 'p=MIG...',
+            type: 'TXT',
+            status: 'verified',
+            ttl: 'Auto',
+          },
+          {
+            record: 'Tracking',
+            name: 'track.resend.com',
+            value: 'tracking.resend.com',
+            type: 'CNAME',
+            ttl: 'Auto',
+            status: 'pending',
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = await resend.domains.get('1234');
+      expect(result.data?.status).toBe('partially_verified');
+    });
+
+    it('get partially_failed domain', async () => {
+      const response: GetDomainResponseSuccess = {
+        object: 'domain',
+        id: 'fd61172c-cafc-40f5-b049-b45947779a29',
+        name: 'resend.com',
+        status: 'partially_failed',
+        created_at: '2023-06-21T06:10:36.144Z',
+        region: 'us-east-1',
+        capabilities: {
+          sending: 'enabled',
+          receiving: 'enabled',
+        },
+        records: [
+          {
+            record: 'DKIM',
+            name: 'resend._domainkey',
+            value: 'p=MIG...',
+            type: 'TXT',
+            status: 'verified',
+            ttl: 'Auto',
+          },
+          {
+            record: 'Receiving',
+            name: 'resend.com',
+            value: 'inbound-mx.resend.com',
+            type: 'MX',
+            ttl: 'Auto',
+            status: 'failed',
+            priority: 10,
+          },
+        ],
+      };
+
+      fetchMock.mockOnce(JSON.stringify(response), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+
+      const result = await resend.domains.get('1234');
+      expect(result.data?.status).toBe('partially_failed');
+    });
   });
 
   describe('update', () => {

--- a/src/domains/interfaces/domain.ts
+++ b/src/domains/interfaces/domain.ts
@@ -25,6 +25,14 @@ export type DomainRecordStatus =
   | 'pending'
   | 'verified'
   | 'failed'
+  | 'not_started'
+  | 'partially_verified'
+  | 'partially_failed';
+
+export type DomainRecordStatus =
+  | 'pending'
+  | 'verified'
+  | 'failed'
   | 'temporary_failure'
   | 'not_started';
 

--- a/src/domains/interfaces/domain.ts
+++ b/src/domains/interfaces/domain.ts
@@ -25,19 +25,14 @@ export type DomainRecordStatus =
   | 'pending'
   | 'verified'
   | 'failed'
-  | 'not_started'
-  | 'partially_verified'
-  | 'partially_failed';
-
-export type DomainRecordStatus =
-  | 'pending'
-  | 'verified'
-  | 'failed'
   | 'temporary_failure'
   | 'not_started';
 
 export type DomainStatus =
-  | DomainRecordStatus
+  | 'pending'
+  | 'verified'
+  | 'failed'
+  | 'not_started'
   | 'partially_verified'
   | 'partially_failed';
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Support new domain statuses and decouple domain vs record status types to match the API and prevent type errors in `domains.get`.

- **Bug Fixes**
  - Explicit `DomainStatus`: `pending`, `verified`, `failed`, `not_started`, `partially_verified`, `partially_failed`; decoupled from `DomainRecordStatus`; bumped `resend` to 6.12.2.
  - Added tests for `domains.get` with `partially_verified` and `partially_failed`.

<sup>Written for commit 79963f250b37cc0889ad9d3a0bd443adb2d811d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

