### PR TITLE
feat: add missing domain types: domains can be partially_verified/partially_failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.12.0",
+  "version": "6.12.1",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/domains/interfaces/domain.ts
+++ b/src/domains/interfaces/domain.ts
@@ -21,12 +21,17 @@ export type DomainNameservers =
   | 'Unidentified'
   | 'Vercel';
 
-export type DomainStatus =
+export type DomainRecordStatus =
   | 'pending'
   | 'verified'
   | 'failed'
   | 'temporary_failure'
   | 'not_started';
+
+export type DomainStatus =
+  | DomainRecordStatus
+  | 'partially_verified'
+  | 'partially_failed';
 
 export type DomainRecords =
   | DomainSpfRecord
@@ -41,7 +46,7 @@ export interface DomainSpfRecord {
   value: string;
   type: 'MX' | 'TXT';
   ttl: string;
-  status: DomainStatus;
+  status: DomainRecordStatus;
   routing_policy?: string;
   priority?: number;
   proxy_status?: 'enable' | 'disable';
@@ -53,7 +58,7 @@ export interface DomainDkimRecord {
   value: string;
   type: 'CNAME' | 'TXT';
   ttl: string;
-  status: DomainStatus;
+  status: DomainRecordStatus;
   routing_policy?: string;
   priority?: number;
   proxy_status?: 'enable' | 'disable';
@@ -65,7 +70,7 @@ export interface ReceivingRecord {
   value: string;
   type: 'MX';
   ttl: string;
-  status: DomainStatus;
+  status: DomainRecordStatus;
   priority: number;
 }
 
@@ -75,7 +80,7 @@ export interface TrackingRecord {
   value: string;
   type: 'CNAME';
   ttl: string;
-  status: DomainStatus;
+  status: DomainRecordStatus;
 }
 
 export interface TrackingCaaRecord {
@@ -84,7 +89,7 @@ export interface TrackingCaaRecord {
   value: string;
   type: 'CAA';
   ttl: string;
-  status: DomainStatus;
+  status: DomainRecordStatus;
 }
 
 export interface Domain {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `partially_verified` and `partially_failed` to `DomainStatus`, and introduced `DomainRecordStatus` for DNS records to exclude partial states. Updated record interfaces to use it and bumped `resend` to 6.12.1.

<sup>Written for commit 73b50f91aef01f6ea607f83637dd9b1b699e0731. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

