### PR TITLE
feat: add `partially_verified` and `partially_failed` to `DomainRecordStatus` type

### DIFF
--- a/src/domains/interfaces/domain.ts
+++ b/src/domains/interfaces/domain.ts
@@ -26,7 +26,9 @@ export type DomainRecordStatus =
   | 'verified'
   | 'failed'
   | 'temporary_failure'
-  | 'not_started';
+  | 'not_started'
+  | 'partially_verified'
+  | 'partially_failed';
 
 export type DomainStatus =
   | 'pending'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `partially_verified` and `partially_failed` as possible values for the `DomainRecordStatus` type, aligning it with the statuses the API can actually return for domain verification records.

The `DomainStatus` type already included these values, but `DomainRecordStatus` (used for individual DNS record verification statuses like SPF, DKIM, Tracking, etc.) was missing them.

### Before

```typescript
export type DomainRecordStatus =
  | 'pending'
  | 'verified'
  | 'failed'
  | 'temporary_failure'
  | 'not_started';
```

### After

```typescript
export type DomainRecordStatus =
  | 'pending'
  | 'verified'
  | 'failed'
  | 'temporary_failure'
  | 'not_started'
  | 'partially_verified'
  | 'partially_failed';
```

All existing tests pass (343 tests across 30 test files).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0AKAHF3F43/p1776884063055469?thread_ts=1776884063.055469&cid=C0AKAHF3F43)

<div><a href="https://cursor.com/agents/bc-373c1f10-d9d2-4739-b6cb-e2826c36eab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-373c1f10-d9d2-4739-b6cb-e2826c36eab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `partially_verified` and `partially_failed` to `DomainRecordStatus` to match API responses for DNS record verification. This avoids type mismatches and enables handling partial states for records like SPF, DKIM, and Tracking.

- **Migration**
  - Update switch/if logic and type guards to handle the two new statuses.
  - Adjust UI/metrics mapping for the new partial statuses if applicable.

<sup>Written for commit 555dfcc7043f5a0389e4ef27a05345bc5b5dcf21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

