### PR TITLE
chore(deps): upgrade `svix` to silence GHSA-w5hq-g745-h8pq

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "homepage": "https://github.com/resend/resend-node#readme",
   "dependencies": {
     "postal-mime": "2.7.4",
-    "svix": "1.90.0"
+    "svix": "1.92.2"
   },
   "peerDependencies": {
     "@react-email/render": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 2.7.4
         version: 2.7.4
       svix:
-        specifier: 1.90.0
-        version: 1.90.0
+        specifier: 1.92.2
+        version: 1.92.2
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.12
@@ -1429,8 +1429,8 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
-  svix@1.90.0:
-    resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
+  svix@1.92.2:
+    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1553,10 +1553,6 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
-
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -2952,10 +2948,9 @@ snapshots:
 
   string-argv@0.3.2: {}
 
-  svix@1.90.0:
+  svix@1.92.2:
     dependencies:
       standardwebhooks: 1.0.0
-      uuid: 10.0.0
 
   tinybench@2.9.0: {}
 
@@ -3046,8 +3041,6 @@ snapshots:
   utf8-byte-length@1.0.5: {}
 
   utils-merge@1.0.1: {}
-
-  uuid@10.0.0: {}
 
   validate-npm-package-name@5.0.1: {}
 


### PR DESCRIPTION
This PR upgrades the dependency `svix` to version 1.92.2 that [removes uuid](https://github.com/svix/svix-webhooks/pull/2286) from its dependencies.
The previously installed version of `uuid` triggers the [security vulnerability GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) when running `npm audit`.

Edit: Maybe unpin both dependencies `postal-mime` and `svix` so consumers of `resend` get bug fixes and security patches of those and their subdependencies without your team needing to push an update and consumers needing to upgrade `resend`?