### PR TITLE
chore: add missing suppressed event to resend node sdk interface

### DIFF
--- a/src/emails/interfaces/get-email-options.interface.ts
+++ b/src/emails/interfaces/get-email-options.interface.ts
@@ -18,7 +18,8 @@ export interface GetEmailResponseSuccess {
     | 'opened'
     | 'queued'
     | 'scheduled'
-    | 'sent';
+    | 'sent'
+    | 'suppressed';
   reply_to: string[] | null;
   subject: string;
   text: string | null;


### PR DESCRIPTION
### Description

This adds a missing suppressed type to email-options-interface type 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 'suppressed' to the email event statuses in `GetEmailResponseSuccess`. This aligns the interface with Resend and prevents type errors when handling suppressed emails.

<sup>Written for commit 3b6dadcbf8fe6e0dfb750306bc3f099539232349. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

