### PR TITLE
chore: bump sdk version to 6.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.12.2",
+  "version": "6.12.3",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `resend` SDK version from 6.12.2 to 6.12.3 to release a patch update.

<sup>Written for commit 88e1177092984e3d24a96af7572d44c9cc375dbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

