### PR TITLE
chore(dev-660): harden github actions workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,11 +14,9 @@ concurrency:
 jobs:
   e2e:
     runs-on: depot-ubuntu-22.04-8
+    timeout-minutes: 15
     container:
       image: node:24-slim
-      # credentials:
-      #   username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
-      #   password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,9 @@ concurrency:
 jobs:
   lint:
     runs-on: depot-ubuntu-22.04-2
+    timeout-minutes: 10
     container:
       image: node:24-slim
-      # credentials:
-      #   username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
-      #   password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/pin-dependencies-check.yml
+++ b/.github/workflows/pin-dependencies-check.yml
@@ -13,11 +13,9 @@ concurrency:
 jobs:
   pin-dependencies-check:
     runs-on: depot-ubuntu-22.04-2
+    timeout-minutes: 5
     container:
       image: node:24-slim
-      # credentials:
-      #   username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
-      #   password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -2,7 +2,8 @@ name: PR Title Check
 on:
   pull_request:
     types: [opened, edited, synchronize]
-permissions: 
+permissions:
+  contents: read
   pull-requests: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,11 +11,9 @@ concurrency:
 jobs:
   pr-title-check:
     runs-on: depot-ubuntu-22.04-2
+    timeout-minutes: 5
     container:
       image: node:24-slim
-      # credentials:
-      #   username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
-      #   password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -13,7 +13,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   preview-release:
     runs-on: depot-ubuntu-22.04-8
-    permissions: 
+    timeout-minutes: 15
+    permissions:
       contents: write
       pull-requests: write
     container:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,9 @@ concurrency:
 jobs:
   tests:
     runs-on: depot-ubuntu-22.04-8
+    timeout-minutes: 15
     container:
       image: node:24-slim
-      # credentials:
-      #   username: ${{ vars.DOCKER_HUB_USERNAME || '' }}
-      #   password: ${{ secrets.DOCKER_HUB_API_KEY || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -7,9 +7,13 @@ on:
     paths:
       - 'src/**/*.ts'
 
+permissions:
+  contents: read
+
 jobs:
   update-docs:
     runs-on: depot-ubuntu-22.04-2
+    timeout-minutes: 10
     name: Trigger Mintlify Agent
     if: github.repository == 'resend/resend-node'
     permissions:


### PR DESCRIPTION
Add top-level `contents: read` permissions where missing, add `timeout-minutes` to every job, and remove the dead commented-out Docker Hub credential blocks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened GitHub Actions by adding top‑level `contents: read` permissions, enforcing `timeout-minutes` on all jobs, and removing dead Docker Hub credential blocks. This addresses the MED and LOW items in DEV‑660 for `resend-node`.

- **Refactors**
  - Added top‑level `permissions: contents: read` to `pr-title-check.yml` and `update-docs.yml`.
  - Set job timeouts: `e2e`/`tests`/`preview-release` = 15m, `lint`/`update-docs` = 10m, `pin-dependencies-check`/`pr-title-check` = 5m.
  - Removed commented Docker Hub credential blocks from all workflow containers.

<sup>Written for commit 8f58815b936e857ba3821ccd34f7a3f52c818af7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

