### PR TITLE
chore: update react-email from v5 to v6.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
     "svix": "1.92.2"
   },
   "peerDependencies": {
-    "@react-email/render": "*"
+    "react-email": "*"
   },
   "peerDependenciesMeta": {
-    "@react-email/render": {
+    "react-email": {
       "optional": true
     }
   },

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,10 +1,10 @@
 export async function render(node: React.ReactNode) {
-  let render: typeof import('@react-email/render').render;
+  let render: typeof import('react-email').render;
   try {
-    ({ render } = await import('@react-email/render'));
+    ({ render } = await import('react-email'));
   } catch {
     throw new Error(
-      'Failed to render React component. Make sure to install `@react-email/render` or `@react-email/components`.',
+      'Failed to render React component. Make sure to install `react-email`.',
     );
   }
 

--- a/src/templates/templates.spec.ts
+++ b/src/templates/templates.spec.ts
@@ -17,7 +17,7 @@ const fetchMocker = createFetchMock(vi);
 fetchMocker.enableMocks();
 
 const mockRenderAsync = vi.fn();
-vi.mock('@react-email/render', () => ({
+vi.mock('react-email', () => ({
   renderAsync: mockRenderAsync,
 }));
 

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -54,11 +54,11 @@ export class Templates {
     if (payload.react) {
       if (!this.renderAsync) {
         try {
-          const { renderAsync } = await import('@react-email/render');
+          const { renderAsync } = await import('react-email');
           this.renderAsync = renderAsync;
         } catch {
           throw new Error(
-            'Failed to render React component. Make sure to install `@react-email/render`',
+            'Failed to render React component. Make sure to install `react-email`',
           );
         }
       }


### PR DESCRIPTION
## Summary

- Replace `@react-email/render` optional peer dependency with `react-email` v6.1.4
- Update dynamic imports and mocks from `@react-email/render` → `react-email`

Closes DEV-503

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade to `react-email` v6.1.4 and replace the optional peer `@react-email/render`, updating dynamic imports, tests, and error messages. Aligns `resend-node` with DEV-503 by using the unified `react-email` API.

- **Migration**
  - Install `react-email` v6+ in your project.
  - Remove `@react-email/render` if it was installed.

<sup>Written for commit 61c31d3ce943a8f65e69f1a8f7753a813880fde2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

