### PR TITLE
feat: add `ContactImports` class for managing contact imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.13.0-preview-imports.0",
+  "version": "6.12.4",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.12.4",
+  "version": "6.13.0-preview-imports.0",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -1,5 +1,6 @@
 import { buildPaginationQuery } from '../common/utils/build-pagination-query';
 import type { Resend } from '../resend';
+import { ContactImports } from './imports/contact-imports';
 import type {
   CreateContactOptions,
   CreateContactRequestOptions,
@@ -31,10 +32,12 @@ import { ContactSegments } from './segments/contact-segments';
 import { ContactTopics } from './topics/contact-topics';
 
 export class Contacts {
+  readonly imports: ContactImports;
   readonly topics: ContactTopics;
   readonly segments: ContactSegments;
 
   constructor(private readonly resend: Resend) {
+    this.imports = new ContactImports(this.resend);
     this.topics = new ContactTopics(this.resend);
     this.segments = new ContactSegments(this.resend);
   }

--- a/src/contacts/imports/contact-imports.spec.ts
+++ b/src/contacts/imports/contact-imports.spec.ts
@@ -2,6 +2,11 @@ import createFetchMock from 'vitest-fetch-mock';
 import { Resend } from '../../resend';
 import { mockSuccessResponse } from '../../test-utils/mock-fetch';
 import type {
+  CreateContactImportOptions,
+  CreateContactImportResponseSuccess,
+} from './interfaces/create-contact-import.interface';
+import type { GetContactImportResponseSuccess } from './interfaces/get-contact-import.interface';
+import type {
   ListContactImportsOptions,
   ListContactImportsResponseSuccess,
 } from './interfaces/list-contact-imports.interface';
@@ -12,6 +17,98 @@ fetchMocker.enableMocks();
 describe('ContactImports', () => {
   afterEach(() => fetchMock.resetMocks());
   afterAll(() => fetchMocker.disableMocks());
+
+  describe('create', () => {
+    it('creates a contact import with multipart form data', async () => {
+      const payload: CreateContactImportOptions = {
+        file: new Blob(['email,first_name\nfoo@example.com,Foo\n'], {
+          type: 'text/csv',
+        }),
+        fileName: 'contacts.csv',
+        columnMap: {
+          email: 'Email',
+          firstName: 'First Name',
+          lastName: 'Last Name',
+          unsubscribed: 'Unsubscribed',
+          properties: {
+            plan: {
+              column: 'Plan',
+              type: 'string',
+            },
+          },
+        },
+        onConflict: 'upsert',
+        onError: 'abort',
+        segments: [{ id: '78261eea-8f8b-4381-83c6-79fa7120f1cf' }],
+        topics: [
+          {
+            id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+            subscription: 'opt_in',
+          },
+        ],
+      };
+      const response: CreateContactImportResponseSuccess = {
+        object: 'contact_import',
+        id: '479e3145-dd38-476b-932c-529ceb705947',
+      };
+
+      mockSuccessResponse(response, { status: 201 });
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.imports.create(payload),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "id": "479e3145-dd38-476b-932c-529ceb705947",
+            "object": "contact_import",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+
+      const [, request] = fetchMock.mock.calls[0];
+      const headers = request?.headers as Headers;
+      const body = request?.body as FormData;
+
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/contacts/imports',
+      );
+      expect(headers.get('Content-Type')).toBeNull();
+      expect(body).toBeInstanceOf(FormData);
+      expect(body.get('file')).toBeTruthy();
+      expect(body.get('column_map')).toBe(
+        JSON.stringify({
+          email: 'Email',
+          first_name: 'First Name',
+          last_name: 'Last Name',
+          unsubscribed: 'Unsubscribed',
+          properties: {
+            plan: {
+              column: 'Plan',
+              type: 'string',
+            },
+          },
+        }),
+      );
+      expect(body.get('on_conflict')).toBe('upsert');
+      expect(body.get('on_error')).toBe('abort');
+      expect(body.get('segments')).toBe(
+        JSON.stringify([{ id: '78261eea-8f8b-4381-83c6-79fa7120f1cf' }]),
+      );
+      expect(body.get('topics')).toBe(
+        JSON.stringify([
+          {
+            id: 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+            subscription: 'opt_in',
+          },
+        ]),
+      );
+    });
+  });
 
   describe('list', () => {
     it('lists contact imports', async () => {
@@ -92,6 +189,56 @@ describe('ContactImports', () => {
 
       expect(fetchMock.mock.calls[0][0]).toBe(
         'https://api.resend.com/contacts/imports?limit=10&status=completed',
+      );
+    });
+  });
+
+  describe('get', () => {
+    it('retrieves a contact import', async () => {
+      const response: GetContactImportResponseSuccess = {
+        object: 'contact_import',
+        id: '479e3145-dd38-476b-932c-529ceb705947',
+        status: 'completed',
+        created_at: '2026-05-15T18:32:37.823Z',
+        completed_at: '2026-05-15T18:33:42.916Z',
+        counts: {
+          total: 1200,
+          created: 800,
+          updated: 300,
+          skipped: 75,
+          failed: 25,
+        },
+      };
+
+      mockSuccessResponse(response, {});
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.imports.get('479e3145-dd38-476b-932c-529ceb705947'),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "completed_at": "2026-05-15T18:33:42.916Z",
+            "counts": {
+              "created": 800,
+              "failed": 25,
+              "skipped": 75,
+              "total": 1200,
+              "updated": 300,
+            },
+            "created_at": "2026-05-15T18:32:37.823Z",
+            "id": "479e3145-dd38-476b-932c-529ceb705947",
+            "object": "contact_import",
+            "status": "completed",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/contacts/imports/479e3145-dd38-476b-932c-529ceb705947',
       );
     });
   });

--- a/src/contacts/imports/contact-imports.spec.ts
+++ b/src/contacts/imports/contact-imports.spec.ts
@@ -24,7 +24,6 @@ describe('ContactImports', () => {
         file: new Blob(['email,first_name\nfoo@example.com,Foo\n'], {
           type: 'text/csv',
         }),
-        fileName: 'contacts.csv',
         columnMap: {
           email: 'Email',
           firstName: 'First Name',

--- a/src/contacts/imports/contact-imports.spec.ts
+++ b/src/contacts/imports/contact-imports.spec.ts
@@ -1,0 +1,98 @@
+import createFetchMock from 'vitest-fetch-mock';
+import { Resend } from '../../resend';
+import { mockSuccessResponse } from '../../test-utils/mock-fetch';
+import type {
+  ListContactImportsOptions,
+  ListContactImportsResponseSuccess,
+} from './interfaces/list-contact-imports.interface';
+
+const fetchMocker = createFetchMock(vi);
+fetchMocker.enableMocks();
+
+describe('ContactImports', () => {
+  afterEach(() => fetchMock.resetMocks());
+  afterAll(() => fetchMocker.disableMocks());
+
+  describe('list', () => {
+    it('lists contact imports', async () => {
+      const response: ListContactImportsResponseSuccess = {
+        object: 'list',
+        has_more: false,
+        data: [
+          {
+            object: 'contact_import',
+            id: '479e3145-dd38-476b-932c-529ceb705947',
+            status: 'completed',
+            created_at: '2026-05-15T18:32:37.823Z',
+            completed_at: '2026-05-15T18:33:42.916Z',
+            counts: {
+              total: 1200,
+              created: 800,
+              updated: 300,
+              skipped: 75,
+              failed: 25,
+            },
+          },
+        ],
+      };
+
+      mockSuccessResponse(response, {});
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await expect(
+        resend.contacts.imports.list(),
+      ).resolves.toMatchInlineSnapshot(`
+        {
+          "data": {
+            "data": [
+              {
+                "completed_at": "2026-05-15T18:33:42.916Z",
+                "counts": {
+                  "created": 800,
+                  "failed": 25,
+                  "skipped": 75,
+                  "total": 1200,
+                  "updated": 300,
+                },
+                "created_at": "2026-05-15T18:32:37.823Z",
+                "id": "479e3145-dd38-476b-932c-529ceb705947",
+                "object": "contact_import",
+                "status": "completed",
+              },
+            ],
+            "has_more": false,
+            "object": "list",
+          },
+          "error": null,
+          "headers": {
+            "content-type": "application/json",
+          },
+        }
+      `);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/contacts/imports',
+      );
+    });
+
+    it('lists contact imports with pagination and status', async () => {
+      const options: ListContactImportsOptions = {
+        limit: 10,
+        status: 'completed',
+      };
+      const response: ListContactImportsResponseSuccess = {
+        object: 'list',
+        has_more: false,
+        data: [],
+      };
+
+      mockSuccessResponse(response, {});
+
+      const resend = new Resend('re_zKa4RCko_Lhm9ost2YjNCctnPjbLw8Nop');
+      await resend.contacts.imports.list(options);
+
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.resend.com/contacts/imports?limit=10&status=completed',
+      );
+    });
+  });
+});

--- a/src/contacts/imports/contact-imports.ts
+++ b/src/contacts/imports/contact-imports.ts
@@ -1,0 +1,28 @@
+import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
+import type { Resend } from '../../resend';
+import type {
+  ListContactImportsOptions,
+  ListContactImportsResponse,
+  ListContactImportsResponseSuccess,
+} from './interfaces/list-contact-imports.interface';
+
+export class ContactImports {
+  constructor(private readonly resend: Resend) {}
+
+  async list(
+    options: ListContactImportsOptions = {},
+  ): Promise<ListContactImportsResponse> {
+    const searchParams = new URLSearchParams(buildPaginationQuery(options));
+
+    if (options.status !== undefined) {
+      searchParams.set('status', options.status);
+    }
+
+    const queryString = searchParams.toString();
+    const url = queryString
+      ? `/contacts/imports?${queryString}`
+      : '/contacts/imports';
+
+    return this.resend.get<ListContactImportsResponseSuccess>(url);
+  }
+}

--- a/src/contacts/imports/contact-imports.ts
+++ b/src/contacts/imports/contact-imports.ts
@@ -1,6 +1,17 @@
 import { buildPaginationQuery } from '../../common/utils/build-pagination-query';
 import type { Resend } from '../../resend';
 import type {
+  ContactImportColumnMap,
+  CreateContactImportOptions,
+  CreateContactImportRequestOptions,
+  CreateContactImportResponse,
+  CreateContactImportResponseSuccess,
+} from './interfaces/create-contact-import.interface';
+import type {
+  GetContactImportResponse,
+  GetContactImportResponseSuccess,
+} from './interfaces/get-contact-import.interface';
+import type {
   ListContactImportsOptions,
   ListContactImportsResponse,
   ListContactImportsResponseSuccess,
@@ -8,6 +19,19 @@ import type {
 
 export class ContactImports {
   constructor(private readonly resend: Resend) {}
+
+  async create(
+    payload: CreateContactImportOptions,
+    options: CreateContactImportRequestOptions = {},
+  ): Promise<CreateContactImportResponse> {
+    const formData = this.buildCreateFormData(payload);
+
+    return this.resend.post<CreateContactImportResponseSuccess>(
+      '/contacts/imports',
+      formData,
+      options,
+    );
+  }
 
   async list(
     options: ListContactImportsOptions = {},
@@ -24,5 +48,67 @@ export class ContactImports {
       : '/contacts/imports';
 
     return this.resend.get<ListContactImportsResponseSuccess>(url);
+  }
+
+  async get(id: string): Promise<GetContactImportResponse> {
+    return this.resend.get<GetContactImportResponseSuccess>(
+      `/contacts/imports/${id}`,
+    );
+  }
+
+  private buildCreateFormData(payload: CreateContactImportOptions): FormData {
+    const formData = new FormData();
+
+    if (payload.fileName !== undefined) {
+      formData.append('file', payload.file, payload.fileName);
+    } else {
+      formData.append('file', payload.file);
+    }
+
+    this.appendJsonField(
+      formData,
+      'column_map',
+      this.buildColumnMap(payload.columnMap),
+    );
+    this.appendStringField(formData, 'on_conflict', payload.onConflict);
+    this.appendStringField(formData, 'on_error', payload.onError);
+    this.appendJsonField(formData, 'segments', payload.segments);
+    this.appendJsonField(formData, 'topics', payload.topics);
+
+    return formData;
+  }
+
+  private buildColumnMap(columnMap?: ContactImportColumnMap) {
+    if (columnMap === undefined) {
+      return undefined;
+    }
+
+    return {
+      email: columnMap.email,
+      first_name: columnMap.firstName,
+      last_name: columnMap.lastName,
+      unsubscribed: columnMap.unsubscribed,
+      properties: columnMap.properties,
+    };
+  }
+
+  private appendJsonField(
+    formData: FormData,
+    name: string,
+    value: unknown,
+  ): void {
+    if (value !== undefined) {
+      formData.append(name, JSON.stringify(value));
+    }
+  }
+
+  private appendStringField(
+    formData: FormData,
+    name: string,
+    value: string | undefined,
+  ): void {
+    if (value !== undefined) {
+      formData.append(name, value);
+    }
   }
 }

--- a/src/contacts/imports/contact-imports.ts
+++ b/src/contacts/imports/contact-imports.ts
@@ -17,6 +17,8 @@ import type {
   ListContactImportsResponseSuccess,
 } from './interfaces/list-contact-imports.interface';
 
+type ContactImportFormFieldValue = string | object | null;
+
 export class ContactImports {
   constructor(private readonly resend: Resend) {}
 
@@ -59,28 +61,24 @@ export class ContactImports {
   private buildCreateFormData(payload: CreateContactImportOptions): FormData {
     const formData = new FormData();
 
-    if (payload.fileName !== undefined) {
-      formData.append('file', payload.file, payload.fileName);
-    } else {
-      formData.append('file', payload.file);
-    }
+    formData.append('file', payload.file);
 
-    this.appendJsonField(
+    this.appendField(
       formData,
       'column_map',
-      this.buildColumnMap(payload.columnMap),
+      this.buildColumnMap(payload.columnMap ?? null),
     );
-    this.appendStringField(formData, 'on_conflict', payload.onConflict);
-    this.appendStringField(formData, 'on_error', payload.onError);
-    this.appendJsonField(formData, 'segments', payload.segments);
-    this.appendJsonField(formData, 'topics', payload.topics);
+    this.appendField(formData, 'on_conflict', payload.onConflict ?? null);
+    this.appendField(formData, 'on_error', payload.onError ?? null);
+    this.appendField(formData, 'segments', payload.segments ?? null);
+    this.appendField(formData, 'topics', payload.topics ?? null);
 
     return formData;
   }
 
-  private buildColumnMap(columnMap?: ContactImportColumnMap) {
-    if (columnMap === undefined) {
-      return undefined;
+  private buildColumnMap(columnMap: ContactImportColumnMap | null) {
+    if (columnMap === null) {
+      return null;
     }
 
     return {
@@ -92,23 +90,18 @@ export class ContactImports {
     };
   }
 
-  private appendJsonField(
+  private appendField(
     formData: FormData,
     name: string,
-    value: unknown,
+    value: ContactImportFormFieldValue,
   ): void {
-    if (value !== undefined) {
-      formData.append(name, JSON.stringify(value));
+    if (value === null) {
+      return;
     }
-  }
 
-  private appendStringField(
-    formData: FormData,
-    name: string,
-    value: string | undefined,
-  ): void {
-    if (value !== undefined) {
-      formData.append(name, value);
-    }
+    formData.append(
+      name,
+      typeof value === 'string' ? value : JSON.stringify(value),
+    );
   }
 }

--- a/src/contacts/imports/interfaces/contact-import.interface.ts
+++ b/src/contacts/imports/interfaces/contact-import.interface.ts
@@ -1,0 +1,22 @@
+export type ContactImportStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'completed'
+  | 'failed';
+
+export interface ContactImportCounts {
+  total: number;
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+}
+
+export interface ContactImport {
+  object: 'contact_import';
+  id: string;
+  status: ContactImportStatus;
+  created_at: string;
+  completed_at: string | null;
+  counts: ContactImportCounts;
+}

--- a/src/contacts/imports/interfaces/create-contact-import.interface.ts
+++ b/src/contacts/imports/interfaces/create-contact-import.interface.ts
@@ -1,0 +1,48 @@
+import type { PostOptions } from '../../../common/interfaces';
+import type { Response } from '../../../interfaces';
+
+export type ContactImportOnConflict = 'upsert' | 'skip';
+export type ContactImportOnError = 'continue' | 'abort';
+export type ContactImportPropertyType = 'string' | 'number' | 'boolean';
+
+export interface ContactImportPropertyMapping {
+  column: string;
+  type?: ContactImportPropertyType;
+}
+
+export interface ContactImportColumnMap {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  unsubscribed?: string;
+  properties?: Record<string, ContactImportPropertyMapping>;
+}
+
+export interface ContactImportSegment {
+  id: string;
+}
+
+export interface ContactImportTopic {
+  id: string;
+  subscription: 'opt_in' | 'opt_out';
+}
+
+export interface CreateContactImportOptions {
+  file: Blob;
+  fileName?: string;
+  columnMap?: ContactImportColumnMap;
+  onConflict?: ContactImportOnConflict;
+  onError?: ContactImportOnError;
+  segments?: ContactImportSegment[];
+  topics?: ContactImportTopic[];
+}
+
+export interface CreateContactImportRequestOptions extends PostOptions {}
+
+export interface CreateContactImportResponseSuccess {
+  object: 'contact_import';
+  id: string;
+}
+
+export type CreateContactImportResponse =
+  Response<CreateContactImportResponseSuccess>;

--- a/src/contacts/imports/interfaces/create-contact-import.interface.ts
+++ b/src/contacts/imports/interfaces/create-contact-import.interface.ts
@@ -29,7 +29,6 @@ export interface ContactImportTopic {
 
 export interface CreateContactImportOptions {
   file: Blob;
-  fileName?: string;
   columnMap?: ContactImportColumnMap;
   onConflict?: ContactImportOnConflict;
   onError?: ContactImportOnError;

--- a/src/contacts/imports/interfaces/get-contact-import.interface.ts
+++ b/src/contacts/imports/interfaces/get-contact-import.interface.ts
@@ -1,0 +1,7 @@
+import type { Response } from '../../../interfaces';
+import type { ContactImport } from './contact-import.interface';
+
+export type GetContactImportResponseSuccess = ContactImport;
+
+export type GetContactImportResponse =
+  Response<GetContactImportResponseSuccess>;

--- a/src/contacts/imports/interfaces/index.ts
+++ b/src/contacts/imports/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './list-contact-imports.interface';

--- a/src/contacts/imports/interfaces/index.ts
+++ b/src/contacts/imports/interfaces/index.ts
@@ -1,1 +1,4 @@
+export * from './contact-import.interface';
+export * from './create-contact-import.interface';
+export * from './get-contact-import.interface';
 export * from './list-contact-imports.interface';

--- a/src/contacts/imports/interfaces/list-contact-imports.interface.ts
+++ b/src/contacts/imports/interfaces/list-contact-imports.interface.ts
@@ -3,33 +3,14 @@ import type {
   PaginationOptions,
 } from '../../../common/interfaces/pagination-options.interface';
 import type { Response } from '../../../interfaces';
-
-export type ContactImportStatus =
-  | 'queued'
-  | 'in_progress'
-  | 'completed'
-  | 'failed';
+import type {
+  ContactImport,
+  ContactImportStatus,
+} from './contact-import.interface';
 
 export type ListContactImportsOptions = PaginationOptions & {
   status?: ContactImportStatus;
 };
-
-export interface ContactImportCounts {
-  total: number;
-  created: number;
-  updated: number;
-  skipped: number;
-  failed: number;
-}
-
-export interface ContactImport {
-  object: 'contact_import';
-  id: string;
-  status: ContactImportStatus;
-  created_at: string;
-  completed_at: string | null;
-  counts: ContactImportCounts;
-}
 
 export type ListContactImportsResponseSuccess = PaginatedData<ContactImport[]>;
 

--- a/src/contacts/imports/interfaces/list-contact-imports.interface.ts
+++ b/src/contacts/imports/interfaces/list-contact-imports.interface.ts
@@ -1,0 +1,37 @@
+import type {
+  PaginatedData,
+  PaginationOptions,
+} from '../../../common/interfaces/pagination-options.interface';
+import type { Response } from '../../../interfaces';
+
+export type ContactImportStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'completed'
+  | 'failed';
+
+export type ListContactImportsOptions = PaginationOptions & {
+  status?: ContactImportStatus;
+};
+
+export interface ContactImportCounts {
+  total: number;
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+}
+
+export interface ContactImport {
+  object: 'contact_import';
+  id: string;
+  status: ContactImportStatus;
+  created_at: string;
+  completed_at: string | null;
+  counts: ContactImportCounts;
+}
+
+export type ListContactImportsResponseSuccess = PaginatedData<ContactImport[]>;
+
+export type ListContactImportsResponse =
+  Response<ListContactImportsResponseSuccess>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './batch/interfaces';
 export * from './broadcasts/interfaces';
 export * from './common/interfaces';
 export * from './contact-properties/interfaces';
+export * from './contacts/imports/interfaces';
 export * from './contacts/interfaces';
 export * from './contacts/segments/interfaces';
 export * from './contacts/topics/interfaces';

--- a/src/resend.ts
+++ b/src/resend.ts
@@ -166,6 +166,13 @@ export class Resend {
     options: PostOptions & IdempotentRequest = {},
   ) {
     const headers = new Headers(this.headers);
+    const isFormData =
+      typeof FormData !== 'undefined' && entity instanceof FormData;
+
+    if (isFormData) {
+      headers.delete('Content-Type');
+    }
+
     if (options.headers) {
       for (const [key, value] of new Headers(options.headers).entries()) {
         headers.set(key, value);
@@ -176,7 +183,7 @@ export class Resend {
     }
     const requestOptions = {
       method: 'POST',
-      body: JSON.stringify(entity),
+      body: isFormData ? entity : JSON.stringify(entity),
       ...options,
       headers,
     };


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `ContactImports` under `resend.contacts.imports` to create, list, and get contact import jobs with multipart CSV uploads, pagination, and status filters. Updates the client to handle `FormData` correctly and exports the new interfaces.

- **New Features**
  - Added `contacts.imports` (`create`, `list`, `get`) via `/contacts/imports`; `create` supports multipart uploads (`file`) with `columnMap`, `onConflict`, `onError`, `segments`, and `topics`; `list` supports pagination and `status` (`queued`, `in_progress`, `completed`, `failed`).
  - Exposed on `Contacts` as `imports`; exported interfaces via `index`.

- **Bug Fixes**
  - `Resend.post` now detects `FormData`, removes `Content-Type`, and sends the form body as-is to support multipart uploads.

<sup>Written for commit c778b2fbdc1e57f9d712a74a331f26cf22881073. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



