### PR TITLE
chore: bump version to 6.12.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "6.12.3",
+  "version": "6.12.4",
   "description": "Node.js library for the Resend API",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `resend` package version from 6.12.3 to 6.12.4 to publish the latest patch. No runtime code changes in this PR.

<sup>Written for commit 5d96f18f82b73ffc51c9bc9438e521807db372c7. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/resend-node/pull/971?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

