### PR TITLE
fix: typos in custom HTML example (readme.md)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ const { data } = await resend.emails.send({
   html: '<strong>it works!</strong>',
 });
 
-console.log(`Emaill ${data.id} with customer HTML content has been sent.`);
+console.log(`Email ${data.id} with custom HTML content has been sent.`);
 ```
 
 ## Send email using React


### PR DESCRIPTION
The "Send email using HTML" example logs:

```js
console.log(`Emaill ${data.id} with customer HTML content has been sent.`);
```

Two small typos: `Emaill` -> `Email`, and `customer HTML` -> `custom HTML` (matching the section prose, "Send an email custom HTML content"). Fixed to:

```js
console.log(`Email ${data.id} with custom HTML content has been sent.`);
```

Docs-only, single line.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes typos in the README "Send email using HTML" example so the console log reads correctly. Changes `Emaill` to `Email` and `customer HTML` to `custom HTML`.

<sup>Written for commit 1595432c4f0796156b0d3c97b63af21fbda55a19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

