### PR TITLE
feat: remove contact import onError option

### DIFF
--- a/src/contacts/imports/contact-imports.spec.ts
+++ b/src/contacts/imports/contact-imports.spec.ts
@@ -37,7 +37,6 @@ describe('ContactImports', () => {
           },
         },
         onConflict: 'upsert',
-        onError: 'abort',
         segments: [{ id: '78261eea-8f8b-4381-83c6-79fa7120f1cf' }],
         topics: [
           {
@@ -94,7 +93,6 @@ describe('ContactImports', () => {
         }),
       );
       expect(body.get('on_conflict')).toBe('upsert');
-      expect(body.get('on_error')).toBe('abort');
       expect(body.get('segments')).toBe(
         JSON.stringify([{ id: '78261eea-8f8b-4381-83c6-79fa7120f1cf' }]),
       );

--- a/src/contacts/imports/contact-imports.ts
+++ b/src/contacts/imports/contact-imports.ts
@@ -69,7 +69,6 @@ export class ContactImports {
       this.buildColumnMap(payload.columnMap ?? null),
     );
     this.appendField(formData, 'on_conflict', payload.onConflict ?? null);
-    this.appendField(formData, 'on_error', payload.onError ?? null);
     this.appendField(formData, 'segments', payload.segments ?? null);
     this.appendField(formData, 'topics', payload.topics ?? null);
 

--- a/src/contacts/imports/interfaces/create-contact-import.interface.ts
+++ b/src/contacts/imports/interfaces/create-contact-import.interface.ts
@@ -2,7 +2,6 @@ import type { PostOptions } from '../../../common/interfaces';
 import type { Response } from '../../../interfaces';
 
 export type ContactImportOnConflict = 'upsert' | 'skip';
-export type ContactImportOnError = 'continue' | 'abort';
 export type ContactImportPropertyType = 'string' | 'number' | 'boolean';
 
 export interface ContactImportPropertyMapping {
@@ -31,7 +30,6 @@ export interface CreateContactImportOptions {
   file: Blob;
   columnMap?: ContactImportColumnMap;
   onConflict?: ContactImportOnConflict;
-  onError?: ContactImportOnError;
   segments?: ContactImportSegment[];
   topics?: ContactImportTopic[];
 }


### PR DESCRIPTION
## Summary
- Remove `onError` from `CreateContactImportOptions`.
- Stop sending `on_error` in contact import create form data.
- Update contact import create test coverage for the new request payload.

## Test plan
- `pnpm vitest run src/contacts/imports/contact-imports.spec.ts --exclude e2e`
- `pnpm run typecheck` (fails: existing TypeScript 6 deprecation for `moduleResolution=node10` in `tsconfig.json`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `onError` option from contact import creation and stopped sending `on_error` in the form payload. Aligns the SDK with the API and removes an unsupported parameter.

- **Migration**
  - Remove any `onError` usage from `CreateContactImportOptions` (and related `ContactImportOnError` types).
  - No replacement; server default error handling is used.
  - `onConflict`, `segments`, and `topics` are unchanged.

<sup>Written for commit 306399ae8380ebda68586439e470e5a9256d69ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

