### PR TITLE
feat: options for html_format in receiving.get

### DIFF
--- a/src/emails/receiving/interfaces/get-receiving-email.interface.ts
+++ b/src/emails/receiving/interfaces/get-receiving-email.interface.ts
@@ -40,3 +40,13 @@ export interface GetReceivingEmailResponseSuccess {
 
 export type GetReceivingEmailResponse =
   Response<GetReceivingEmailResponseSuccess>;
+
+export interface GetReceivingEmailOptions {
+  /**
+   * Controls how inline images are returned inside `html`. By default (or when
+   * set to `'data_uri'`), inline images appear in `html` as base64 `data:` URIs.
+   * Set to `'cid'` to keep the original `<img src="cid:..." />` references
+   * instead, each of which matches the `content_id` of an attachment.
+   */
+  html_format?: 'data_uri' | 'cid';
+}

--- a/src/emails/receiving/receiving.spec.ts
+++ b/src/emails/receiving/receiving.spec.ts
@@ -203,6 +203,79 @@ describe('Receiving', () => {
         `);
       });
     });
+
+    describe('query parameters', () => {
+      it('supports the html_format parameter', async () => {
+        const apiResponse: GetReceivingEmailResponseSuccess = {
+          object: 'email' as const,
+          id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          to: ['received@example.com'],
+          from: 'sender@example.com',
+          created_at: '2023-04-07T23:13:52.669661+00:00',
+          subject: 'Test inbound email',
+          html: '<p>hello world</p>',
+          text: 'hello world',
+          bcc: null,
+          cc: null,
+          reply_to: null,
+          headers: {},
+          raw: null,
+          attachments: [],
+          message_id: 'msg_123',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(apiResponse), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        await resend.emails.receiving.get(
+          '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          { html_format: 'cid' },
+        );
+
+        expect(fetchMock.mock.calls[0][0]).toBe(
+          'https://api.resend.com/emails/receiving/67d9bcdb-5a02-42d7-8da9-0d6feea18cff?html_format=cid',
+        );
+      });
+
+      it('omits the query string when no options are passed', async () => {
+        const apiResponse: GetReceivingEmailResponseSuccess = {
+          object: 'email' as const,
+          id: '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+          to: ['received@example.com'],
+          from: 'sender@example.com',
+          created_at: '2023-04-07T23:13:52.669661+00:00',
+          subject: 'Test inbound email',
+          html: '<p>hello world</p>',
+          text: 'hello world',
+          bcc: null,
+          cc: null,
+          reply_to: null,
+          headers: {},
+          raw: null,
+          attachments: [],
+          message_id: 'msg_123',
+        };
+
+        fetchMock.mockOnce(JSON.stringify(apiResponse), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+
+        await resend.emails.receiving.get(
+          '67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+        );
+
+        expect(fetchMock.mock.calls[0][0]).toBe(
+          'https://api.resend.com/emails/receiving/67d9bcdb-5a02-42d7-8da9-0d6feea18cff',
+        );
+      });
+    });
   });
 
   describe('list', () => {

--- a/src/emails/receiving/receiving.ts
+++ b/src/emails/receiving/receiving.ts
@@ -8,6 +8,7 @@ import type {
   ForwardReceivingEmailResponseSuccess,
 } from './interfaces/forward-receiving-email.interface';
 import type {
+  GetReceivingEmailOptions,
   GetReceivingEmailResponse,
   GetReceivingEmailResponseSuccess,
 } from './interfaces/get-receiving-email.interface';
@@ -24,10 +25,22 @@ export class Receiving {
     this.attachments = new Attachments(resend);
   }
 
-  async get(id: string): Promise<GetReceivingEmailResponse> {
-    const data = await this.resend.get<GetReceivingEmailResponseSuccess>(
-      `/emails/receiving/${id}`,
-    );
+  async get(
+    id: string,
+    options: GetReceivingEmailOptions = {},
+  ): Promise<GetReceivingEmailResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (options.html_format !== undefined) {
+      searchParams.set('html_format', options.html_format);
+    }
+
+    const queryString = searchParams.toString();
+    const path = queryString
+      ? `/emails/receiving/${id}?${queryString}`
+      : `/emails/receiving/${id}`;
+
+    const data = await this.resend.get<GetReceivingEmailResponseSuccess>(path);
 
     return data;
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an optional `html_format` option to `receiving.get` to control how inline images appear in `html` (supports `'cid'` in addition to existing `'data_uri'`). Defaults to previous behavior and only appends a query string when an option is provided.

- **New Features**
  - `receiving.get(id, { html_format: 'cid' | 'data_uri' })` builds `/emails/receiving/:id?html_format=...` when set.
  - Introduced `GetReceivingEmailOptions` and added tests for both the query param and the no-options case.

<sup>Written for commit 5f1f699b8881cc6f6f45ca51b880c56010baa266. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-node/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

